### PR TITLE
Fix #54: PATCHing a draft resets its links

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           name: Install requirements
           command: |
             apk update && apk upgrade
-            apk add bash bash-completion build-base git perl mariadb-dev
+            apk add bash bash-completion build-base git perl mariadb-dev libffi-dev
             python3.5 -m venv /blockstore/venv
             source /blockstore/venv/bin/activate
             make requirements
@@ -60,7 +60,7 @@ jobs:
           name: Install requirements
           command: |
             apk update && apk upgrade
-            apk add bash bash-completion build-base git perl mariadb-dev
+            apk add bash bash-completion build-base git perl mariadb-dev libffi-dev
             python3.5 -m venv /blockstore/venv
             source /blockstore/venv/bin/activate
             make requirements

--- a/blockstore/apps/api/routers.py
+++ b/blockstore/apps/api/routers.py
@@ -6,7 +6,9 @@ from rest_framework_nested import routers
 
 
 class DefaultRouter(routers.DefaultRouter):
-
+    """
+    Customized version of DefaultRouter used for the Blockstore REST API
+    """
     def get_lookup_regex(self, viewset, lookup_prefix=''):
         """
         Given a viewset, return the portion of URL regex that is used

--- a/blockstore/apps/api/v1/views/drafts.py
+++ b/blockstore/apps/api/v1/views/drafts.py
@@ -185,4 +185,4 @@ class DraftViewSet(viewsets.ModelViewSet):
         """
         draft_repo = DraftRepo(SnapshotRepo())
         draft_repo.delete(uuid)
-        return super().destroy(request, uuid)
+        return super().destroy(request, uuid)  # pylint: disable=no-member

--- a/blockstore/apps/bundles/links.py
+++ b/blockstore/apps/bundles/links.py
@@ -59,7 +59,6 @@ class Link:
 
 class LinkCycleError(ValueError):
     """Raise when an action would create a cycle between two BundleVersions."""
-    pass
 
 
 class LinkCollection:
@@ -144,6 +143,10 @@ class LinkCollection:
                 )
 
     def _check_for_cycles(self, bundle_uuid, links):
+        """
+        Check for link cycles (when a bundle's links have links [that have
+        links...] that point back to the bundle.)
+        """
         for link in links:
             if link.direct_dependency == bundle_uuid:
                 raise LinkCycleError(

--- a/blockstore/apps/bundles/models.py
+++ b/blockstore/apps/bundles/models.py
@@ -143,6 +143,9 @@ class BundleVersion(models.Model):
 
     @classmethod
     def create_new_version(cls, bundle_uuid, snapshot_digest):
+        """
+        Create a new BundleVersion for the specified Bundle.
+        """
         bundle = Bundle.objects.get(uuid=bundle_uuid)
         versions = list(bundle.versions.order_by('-version_num')[:1])
         next_version_num = versions[0].version_num + 1 if versions else 1

--- a/blockstore/apps/bundles/store.py
+++ b/blockstore/apps/bundles/store.py
@@ -30,11 +30,6 @@ logger = logging.getLogger(__name__)
 snapshot_created = Signal(providing_args=["bundle_uuid", "hash_digest"])
 
 
-# Pylint doesn't know how to introspect attr.s() structs, and can't tell that
-# Snapshot.files or StagedDraft.files_to_overwrite are in fact dicts and can do
-# all of the things listed below:
-# pylint: disable=unsubscriptable-object,unsupported-membership-test,not-an-iterable
-
 @attr.s(frozen=True)
 class FileInfo:
     """
@@ -390,6 +385,9 @@ class DraftRepo:
         return self.storage.save(path, file_obj)
 
     def _save_summary_file(self, draft):
+        """
+        Save this draft's summary file
+        """
         # Before we save the Draft, create a LinkCollection to ensure that we
         # haven't introduced a cycle:
         _new_link_collection = draft.composed_links()

--- a/blockstore/apps/bundles/tests/test_models.py
+++ b/blockstore/apps/bundles/tests/test_models.py
@@ -107,7 +107,9 @@ class TestToString(TestCase):
 
 @isolate_test_storage
 class TestDraftCreation(TestCase):
-
+    """
+    Test creation of a new draft
+    """
     def test_save_creates_staged_draft(self):
         collection = Collection.objects.create(title="Collection 1")
         bundle = Bundle.objects.create(

--- a/blockstore/apps/bundles/tests/test_store.py
+++ b/blockstore/apps/bundles/tests/test_store.py
@@ -31,7 +31,9 @@ TEXT_FILE = ContentFile(TEXT_CONTENT_BYTES)
 
 
 class TestFileInfo(unittest.TestCase):
-
+    """
+    Basic tests of the FileInfo structure
+    """
     def test_serialization(self):
         """
         Test creation from Python primitives (that you'd get from JSON parsing).
@@ -126,8 +128,8 @@ class TestSnapshots(SimpleTestCase):
         self.assertNotEqual(snapshot_1, snapshot_2)
         self.assertNotEqual(snapshot_1.hash_digest, snapshot_2.hash_digest)
         self.assertEqual(
-            snapshot_1.files['test.txt'].hash_digest,  # pylint: disable=unsubscriptable-object
-            snapshot_2.files['renamed.txt'].hash_digest,  # pylint: disable=unsubscriptable-object
+            snapshot_1.files['test.txt'].hash_digest,
+            snapshot_2.files['renamed.txt'].hash_digest,
         )
 
     def test_snapshot_not_found(self):

--- a/blockstore/apps/core/constants.py
+++ b/blockstore/apps/core/constants.py
@@ -1,7 +1,7 @@
 """ Constants for the core app. """
 
 
-class Status(object):
+class Status:
     """Health statuses."""
     OK = u"OK"
     UNAVAILABLE = u"UNAVAILABLE"

--- a/blockstore/apps/core/models.py
+++ b/blockstore/apps/core/models.py
@@ -17,11 +17,11 @@ class User(AbstractUser):
         Assumes user has authenticated at least once with the OAuth2 provider (LMS).
         """
         try:
-            return self.social_auth.first().extra_data[u'access_token']
+            return self.social_auth.first().extra_data['access_token']  # pylint: disable=no-member
         except Exception:  # pylint: disable=broad-except
             return None
 
-    class Meta(object):
+    class Meta:
         get_latest_by = 'date_joined'
 
     def get_full_name(self):

--- a/blockstore/apps/core/tests/test_models.py
+++ b/blockstore/apps/core/tests/test_models.py
@@ -19,7 +19,7 @@ class UserTests(TestCase):
         self.assertIsNone(user.access_token)
 
         access_token = 'My voice is my passport. Verify me.'
-        social_auth.extra_data['access_token'] = access_token
+        social_auth.extra_data['access_token'] = access_token  # pylint: disable=unsupported-assignment-operation
         social_auth.save()
         self.assertEqual(user.access_token, access_token)
 

--- a/blockstore/settings/base.py
+++ b/blockstore/settings/base.py
@@ -281,7 +281,7 @@ LOGGING = {
     'loggers': {
         'django': {
             'handlers': ['console', 'local'],
-            'propagate': True,
+            'propagate': False,
             'level': 'INFO'
         },
         'requests': {

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,7 +1,7 @@
 # Packages required for testing
 -r base.txt
 
-astroid<1.6
+astroid
 coverage
 ddt
 diff-cover

--- a/tagstore/backends/tagstore_django/templatetags/tagstore_admin.py
+++ b/tagstore/backends/tagstore_django/templatetags/tagstore_admin.py
@@ -14,4 +14,4 @@ def tag_hierarchy(taxonomy_uid):
         tags = tagstore.get_tags_in_taxonomy_hierarchically_as_dict(taxonomy_uid)
         return {'tags': tags, 'taxonomy_uid': taxonomy_uid}
     else:
-        return
+        return None

--- a/tagstore/backends/tests/test_backends.py
+++ b/tagstore/backends/tests/test_backends.py
@@ -53,9 +53,9 @@ class AbstractBackendTest:
     def test_add_tag_to_taxonomy(self):
         """ add_tag_to_taxonomy will add a tag to the given taxonomy """
         tax = self.tagstore.create_taxonomy("TestTax", owner_id=some_user)
-        self.assertEqual(len([t for t in tax.list_tags()]), 0)
+        self.assertEqual(len(list(tax.list_tags())), 0)
         tag = tax.add_tag('testing')
-        tags = [t for t in tax.list_tags()]
+        tags = list(tax.list_tags())
         self.assertEqual(len(tags), 1)
         self.assertEqual(tags[0], tag)
         tag2 = tax.add_tag('testing 2')
@@ -69,11 +69,11 @@ class AbstractBackendTest:
         Searching for tags is always case-insensitive.
         """
         tax = self.tagstore.create_taxonomy("TestTax", owner_id=some_user)
-        self.assertEqual(len([t for t in tax.list_tags()]), 0)
+        self.assertEqual(len(list(tax.list_tags())), 0)
         tag1 = tax.add_tag('testing')
         tag2 = tax.add_tag('Testing')
         self.assertEqual(tag2.name, 'testing')  # It should have returned the existing tag's case
-        tags = set([t for t in tax.list_tags()])
+        tags = set(tax.list_tags())
         self.assertEqual(len(tags), 1)
         self.assertEqual(tags, {tag1, tag2})
         # get_tag should also respect the original case:
@@ -94,7 +94,7 @@ class AbstractBackendTest:
         tax = self.tagstore.create_taxonomy("TestTax", owner_id=some_user)
         for tag in valid_tags:
             tax.add_tag(tag)
-        tags_created = set([t.name for t in tax.list_tags()])
+        tags_created = set(t.name for t in tax.list_tags())
         self.assertEqual(tags_created, set(valid_tags))
 
     def test_forbidden_tag_names(self):
@@ -120,7 +120,7 @@ class AbstractBackendTest:
         tag1 = tax.add_tag('testing')
         tag2 = tax.add_tag('testing')
         self.assertEqual(tag1, tag2)
-        tags = [t for t in tax.list_tags()]
+        tags = list(tax.list_tags())
         self.assertEqual(tags, [tag1])
 
     def test_add_tag_to_taxonomy_idempotent_parent(self):
@@ -133,8 +133,7 @@ class AbstractBackendTest:
         child1 = tax.add_tag('child', parent_tag=parent)
         child2 = tax.add_tag('child', parent_tag=parent)
         self.assertEqual(child1, child2)
-        tags = [t for t in tax.list_tags()]
-        self.assertEqual(len(tags), 2)  # the 2 tags are 'parent' and 'child'
+        self.assertEqual(len(list(tax.list_tags())), 2)  # the 2 tags are 'parent' and 'child'
 
     def test_add_tag_to_taxonomy_exists_elsewhere(self):
         """ add_tag_to_taxonomy will not allow a child that exists elsewhere """
@@ -374,7 +373,7 @@ class AbstractBackendTest:
         self.assertEqual(result, {elephant})
 
         # large mammals:
-        result = set([e for e in self.tagstore.get_entities_tagged_with_all({large, mammal})])
+        result = set(self.tagstore.get_entities_tagged_with_all({large, mammal}))
         self.assertEqual(result, {elephant})
 
     def test_get_entities_tagged_with_all_invalid(self):

--- a/tagstore/tagstore_rest/v1/tests/test_views.py
+++ b/tagstore/tagstore_rest/v1/tests/test_views.py
@@ -1,5 +1,5 @@
 """ Tests for api v1 views. """
-from future.moves.urllib.parse import urlencode
+from urllib.parse import urlencode
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase

--- a/tagstore/tagstore_rest/v1/views/entities.py
+++ b/tagstore/tagstore_rest/v1/views/entities.py
@@ -30,14 +30,14 @@ class EntityViewSet(viewsets.ViewSet):
     queryset = Entity.objects.all()
     serializer_class = EntitySerializer
 
-    def list(self, request, *args, **kwargs):  # pylint: disable=unused-argument
+    def list(self, request, *args, **kwargs):
         '''
         Get a list of all entities.
         '''
         serializer = EntitySerializer(self.queryset, many=True)
         return Response(serializer.data)
 
-    def retrieve(self, request, pk=None, entity_type=None):  # pylint: disable=unused-argument
+    def retrieve(self, request, pk=None, entity_type=None):
         '''
         Get a single entity.
         '''


### PR DESCRIPTION
## Description

This is a fix for #54.

It also:
* Includes a ton of minor pylint fixes to get the build passing again with the current version of `edx-lint`
* Fixes the logging configuration to stop every request from being logged twice.
