### PR TITLE
Add missing dependency

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -5,7 +5,7 @@ FROM python:3.5.7-alpine3.9
 ENV VIRTUAL_ENV=/blockstore/venv
 
 RUN apk update && apk upgrade
-RUN apk add bash bash-completion build-base git perl mariadb-dev
+RUN apk add bash bash-completion build-base git perl mariadb-dev libffi-dev
 
 RUN python3.5 -m venv $VIRTUAL_ENV
 

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ test: clean ## Run tests and generate coverage report
 	${VENV_BIN}/coverage xml
 	${VENV_BIN}/diff-cover coverage.xml --html-report diff-cover.html
 
-easyserver: pull dev.up dev.provision  # Start and provision a Blockstore container and run the server until CTRL-C, then stop it
+easyserver: dev.up dev.provision  # Start and provision a Blockstore container and run the server until CTRL-C, then stop it
 	# Now run blockstore until the user hits CTRL-C:
 	docker-compose --project-name blockstore -f docker-compose.yml exec blockstore /blockstore/venv/bin/python /blockstore/app/manage.py runserver 0.0.0.0:18250
 	# Then stop the container:

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ dev.provision:  # Provision Blockstore service
 stop:  # Stop Blockstore container
 	docker-compose --project-name blockstore -f docker-compose.yml stop
 
+pull:  # Update docker images that this depends on.
+	docker pull python:3.5.7-alpine3.9
+
 destroy:  # Remove Blockstore container, network and volumes. Destructive.
 	docker-compose --project-name blockstore -f docker-compose.yml down -v
 
@@ -62,7 +65,7 @@ test: clean ## Run tests and generate coverage report
 	${VENV_BIN}/coverage xml
 	${VENV_BIN}/diff-cover coverage.xml --html-report diff-cover.html
 
-easyserver: dev.up dev.provision  # Start and provision a Blockstore container and run the server until CTRL-C, then stop it
+easyserver: pull dev.up dev.provision  # Start and provision a Blockstore container and run the server until CTRL-C, then stop it
 	# Now run blockstore until the user hits CTRL-C:
 	docker-compose --project-name blockstore -f docker-compose.yml exec blockstore /blockstore/venv/bin/python /blockstore/app/manage.py runserver 0.0.0.0:18250
 	# Then stop the container:

--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,10 @@ clean: ## Remove all generated files
 	rm -f diff-cover.html
 
 requirements: ## Install requirements for development
-	${VENV_BIN}/pip install -qr requirements/local.txt --exists-action w
+	${VENV_BIN}/pip install -r requirements/local.txt --exists-action w
 
 requirements-test: ## Install requirements for testing
-	${VENV_BIN}/pip install -qr requirements/test.txt --exists-action w
+	${VENV_BIN}/pip install -r requirements/test.txt --exists-action w
 
 production-requirements:
 	pip install -r requirements/production.txt --exists-action w


### PR DESCRIPTION
## Description

This fixes installing the cffi python library (a dependency of a dependency). Building cffi requires libffi-dev installed. 

This also adds a `pull` make target as a convenience to update the underlying docker image, and removes the quiet flag from some pip install commands to help debugging.

## Author Comments, Concerns, and Open Questions

Because docker aggresively caches things, others could run into this problem even with this patch included. Perhaps we need a note in the readme and/or a make target to point towards running `docker-compose build --no-cache` to force rebuild the blockstore image?

## Test Instructions

1. `make destroy` to begin with a clean slate
1. `make pull` to update the docker base image
1. `docker-compose build --no-cache` to rebuild the docker image
1. `make easyserver` to provision and build the blockstore instance
1. verify that provisioning completed successfully and server begins serving


## TODOs

If anything isn't yet done, list it here
- [ ] Squash before merging

## Reviewers

- [ ] @bradenmacdonald ?
- [ ] TBD