### PR TITLE
Add openedx.yaml (OEP-2 & OEP-10)

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -1,0 +1,9 @@
+# openedx.yaml
+
+---
+owner:
+    type: team
+    team: edx/teaching-and-learning
+tags:
+    - backend-service  # End users access LMS/Studio which in turn make requests to Blockstore
+openedx-release: {ref: master}


### PR DESCRIPTION
## Description

This adds an `openedx.yaml` file now that Blockstore is part of the `edx` org, and so that it can be tagged for Open edX named releases in the future.

FYI @nedbat 