### PR TITLE
[BD-6] Fix API schema generation

### DIFF
--- a/blockstore/settings/base.py
+++ b/blockstore/settings/base.py
@@ -236,6 +236,8 @@ REST_FRAMEWORK = {
         # token are allowed to use the API.
         'blockstore.apps.api.permissions.IsSuperUserOrAuthorizedApplication',
     ),
+    # TODO: Remove once we move to edx/api-doc-tools
+    'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema',
 }
 
 ################################################################################

--- a/blockstore/settings/production.py
+++ b/blockstore/settings/production.py
@@ -16,6 +16,8 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.BasicAuthentication',
     ),
+    # TODO: Remove once we move to edx/api-doc-tools
+    'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema',
 }
 
 CONFIG_FILE = get_env_setting('BLOCKSTORE_CFG')


### PR DESCRIPTION
This is pretty similar to: https://github.com/edx/edx-analytics-data-api/pull/359

api-docs/ throws:
```
AttributeError at /api-docs/
'AutoSchema' object has no attribute 'get_link'
```

The solution was taken again from this [link](https://stackoverflow.com/questions/57654243/how-to-fix-attributeerror-at-api-doc-autoschema-object-has-no-attribute-ge)

And this is on the DRF [documentation](https://www.django-rest-framework.org/community/3.10-announcement/#continuing-to-use-coreapi)

I think that we should move to https://github.com/edx/api-doc-tools once it supports a way to generate the api docs for the tagstore APIs

## After the change:

![image](https://user-images.githubusercontent.com/22335041/83176497-878aca00-a0eb-11ea-82f4-2fa0b738e5c0.png)

## How to test:
- Go to /api-docs/ and it should render the documentation.

## Reviewers
- [ ] @awais786
- [x] @ericfab179