### PR TITLE
SE-3116 Pin django-waffle to 1.0.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,7 +5,7 @@ django-cors-headers>=2.2.0,<2.3
 django-environ==0.4.5
 django-extensions
 django-rest-swagger
-django-waffle
+django-waffle==1.0.0
 djangorestframework
 djangorestframework-expander
 django-filter==2.1.0


### PR DESCRIPTION
With django-waffle 2.0.0, `make easyserver` fails with

```
/blockstore/venv/bin/python manage.py migrate --no-input
SystemCheckError: System check identified some issues:

ERRORS:
waffle.Flag.everyone: (fields.E110) BooleanFields do not accept null values.
        HINT: Use a NullBooleanField instead.
```

There may be a better way to fix this, but it is unknown where the
source of the error is.

**Jira tickets**: [OSPR-4953](https://openedx.atlassian.net/browse/OSPR-4953)

## Author Comments, Concerns, and Open Questions

Why did this break? I couldn't find much about this error or where it originates.  There is a BooleanField ([`uses_latest`](https://github.com/open-craft/blockstore/blob/938b768e4b22559d621b97205d65da38e608ec1e/blockstore/apps/bundles/models.py#L249)) that has no default, but I still got this error after adding a default.

## Test Instructions

- checkout this branch, clean everything (`make destroy`), and run `make easyserver`
- verify that provisioning succeeds and the server is usable

## TODOs
If anything isn't yet done, list it here
- [ ] Squash before merging

## Reviewers

- [ ] @symbolist 
- [ ] edX reviewer TBD
