### PR TITLE
[SE-3242] Upgrade blockstore to use Python 3.8 and Django 2.2+.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 # Dockerfile
 
-FROM python:3.5.7-alpine3.9
+FROM python:3.8.5-alpine3.12
 
 ENV VIRTUAL_ENV=/blockstore/venv
 
 RUN apk update && apk upgrade
 RUN apk add bash bash-completion build-base git perl mariadb-dev libffi-dev
 
-RUN python3.5 -m venv $VIRTUAL_ENV
+RUN python3.8 -m venv $VIRTUAL_ENV
 
 RUN echo 'cd /blockstore/app/' >> ~/.bashrc
 RUN echo 'export PATH=$VIRTUAL_ENV/bin:$PATH' >> ~/.bashrc

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,13 +1,13 @@
 # Dockerfile for dev.
 
-FROM python:3.5.7-alpine3.9
+FROM python:3.8.5-alpine3.12
 
 ENV VIRTUAL_ENV=/blockstore/venv
 
 RUN apk update && apk upgrade
 RUN apk add bash bash-completion build-base git perl mariadb-dev libffi-dev
 
-RUN python3.5 -m venv $VIRTUAL_ENV
+RUN python3.8 -m venv $VIRTUAL_ENV
 
 RUN echo 'cd /blockstore/app/' >> ~/.bashrc
 RUN echo 'export PATH=$VIRTUAL_ENV/bin:$PATH' >> ~/.bashrc

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ stop:  # Stop Blockstore container
 	docker-compose --project-name blockstore -f docker-compose.yml stop
 
 pull:  # Update docker images that this depends on.
-	docker pull python:3.5.7-alpine3.9
+	docker pull python:3.8.5-alpine3.12
 
 destroy:  # Remove Blockstore container, network and volumes. Destructive.
 	docker-compose --project-name blockstore -f docker-compose.yml down -v

--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,39 @@ Prerequisite: Have your Open edX `Devstack <https://github.com/edx/devstack>`_ p
    #. In ``private.py``, set ``SOCIAL_AUTH_EDX_OAUTH2_SECRET`` to the random "Client secret" value.
    #. Now you can login at http://localhost:18250/login/
 
+Running Tests
+--------
+
+To run the unit tests, get into the blockstore container:
+
+```
+docker-compose --project-name blockstore -f docker-compose.yml exec blockstore /bin/bash
+```
+
+And then run:
+
+```
+make test
+```
+
+To save on overhead while running individual tests, from within the container, you can do:
+
+```
+DJANGO_SETTINGS_MODULE=blockstore.settings.test ./manage.py test dotted.path.To.test
+```
+
+To run a testserver for use with the edx-platform unit tests, run (on the host machine):
+
+```
+make testserver
+```
+
+And from within the studio shell, run:
+
+```
+EDXAPP_RUN_BLOCKSTORE_TESTS=1 paver test_system -s cms -t cms/djangoapps/contentstore/tests -t openedx/core/djangoapps/content_libraries
+```
+
 Get Help
 --------
 

--- a/blockstore/apps/api/urls.py
+++ b/blockstore/apps/api/urls.py
@@ -6,6 +6,8 @@ contain namespaces for the active versions of the API.
 """
 from django.conf.urls import url, include
 
+app_name = 'blockstore'
+
 urlpatterns = [
     url(r'^v1/', include('blockstore.apps.api.v1.urls', namespace='v1')),
 ]

--- a/blockstore/apps/api/v1/tests/test_contract.py
+++ b/blockstore/apps/api/v1/tests/test_contract.py
@@ -318,6 +318,7 @@ class DraftsTest(ApiTestCase):
         )
         file_url = bundle_version_detail_data['snapshot']['files']['hello.txt']['url']
         assert file_url.startswith('http'), "Response URLs should be absolute"
+        print('File URL is!', file_url)
         file_response = self.client.get(file_url)
         assert response_str_file(file_response) == "Hello World! 😀"
 

--- a/blockstore/apps/api/v1/urls.py
+++ b/blockstore/apps/api/v1/urls.py
@@ -7,6 +7,8 @@ from .views.bundles import BundleViewSet, BundleVersionViewSet
 from .views.collections import CollectionViewSet
 from .views.drafts import DraftViewSet
 
+app_name = 'blockstore'
+
 root_router = DefaultRouter(trailing_slash=False)
 
 root_router.register(r'bundles', BundleViewSet)

--- a/blockstore/apps/bundles/models.py
+++ b/blockstore/apps/bundles/models.py
@@ -92,7 +92,8 @@ class Bundle(models.Model):
     title = models.CharField(max_length=MAX_CHAR_FIELD_LENGTH, db_index=True)
 
     collection = models.ForeignKey(
-        Collection, related_name="bundles", related_query_name="bundle", editable=False
+        Collection, related_name="bundles", related_query_name="bundle", editable=False,
+        on_delete=models.CASCADE,
     )
 
     slug = models.SlugField(allow_unicode=True)  # For pretty URLs
@@ -124,7 +125,8 @@ class BundleVersion(models.Model):
     """
     id = models.BigAutoField(primary_key=True)
     bundle = models.ForeignKey(
-        Bundle, related_name="versions", related_query_name="version", editable=False
+        Bundle, related_name="versions", related_query_name="version", editable=False,
+        on_delete=models.CASCADE,
     )
     version_num = models.PositiveIntegerField(editable=False)
     # This is a CharField only because Django ORM doens't support indexed binary
@@ -192,7 +194,8 @@ class Draft(models.Model):
     id = models.BigAutoField(primary_key=True)
     uuid = models.UUIDField(default=uuid.uuid4, unique=True, editable=False)
     bundle = models.ForeignKey(
-        Bundle, related_name="drafts", related_query_name="draft", editable=False
+        Bundle, related_name="drafts", related_query_name="draft", editable=False,
+        on_delete=models.CASCADE,
     )
     name = models.CharField(max_length=MAX_CHAR_FIELD_LENGTH)
 

--- a/blockstore/apps/bundles/tests/factories.py
+++ b/blockstore/apps/bundles/tests/factories.py
@@ -6,19 +6,19 @@ from ..store import FileInfo
 from ..models import Bundle, BundleVersion, Collection
 
 
-class BundleFactory(factory.DjangoModelFactory):
+class BundleFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = Bundle
 
 
-class BundleVersionFactory(factory.DjangoModelFactory):
+class BundleVersionFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = BundleVersion
 
 
-class CollectionFactory(factory.DjangoModelFactory):
+class CollectionFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = Collection

--- a/blockstore/apps/bundles/tests/storage_utils.py
+++ b/blockstore/apps/bundles/tests/storage_utils.py
@@ -111,6 +111,8 @@ def serve_media(request, path):
     inefficient in-proc file serving in a real environment, but it also means
     that the URL pattern won't be added for tests by default.
     """
+    print('Root is', settings.MEDIA_ROOT)
+    print(path)
     return serve(request, path, document_root=settings.MEDIA_ROOT)
 
 

--- a/blockstore/settings/base.py
+++ b/blockstore/settings/base.py
@@ -68,7 +68,6 @@ MIDDLEWARE = (
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'social_django.middleware.SocialAuthExceptionMiddleware',

--- a/blockstore/urls.py
+++ b/blockstore/urls.py
@@ -27,11 +27,11 @@ from blockstore.apps.bundles.tests.storage_utils import url_for_test_media
 admin.autodiscover()
 
 urlpatterns = oauth2_urlpatterns + [
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
     url(r'^api/', include('blockstore.apps.api.urls', namespace='api')),
     url(r'^api-docs/', get_swagger_view(title='blockstore API')),
     # Use the same auth views for all logins, including those originating from the browseable API.
-    url(r'^api-auth/', include(oauth2_urlpatterns, namespace='rest_framework')),
+    url(r'^api-auth/', include((oauth2_urlpatterns, 'auth_backends'), namespace='rest_framework')),
     url(r'^auto_auth/$', core_views.AutoAuth.as_view(), name='auto_auth'),
     url(r'^health/$', core_views.health, name='health'),
     url(r'^tagstore/', include('tagstore.tagstore_rest.urls', namespace='tagstore')),

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 attrs<19.0.0
 pyblake2
-django>=1.11,<1.12
+django>=2.2.16,<2.3
 django-cors-headers>=2.2.0,<2.3
 django-environ==0.4.5
 django-extensions

--- a/tagstore/backends/tagstore_django/models.py
+++ b/tagstore/backends/tagstore_django/models.py
@@ -67,7 +67,7 @@ class Tag(models.Model):
     A tag within a taxonomy
     """
     id = models.BigAutoField(primary_key=True)
-    taxonomy = models.ForeignKey(Taxonomy, null=False)
+    taxonomy = models.ForeignKey(Taxonomy, null=False, on_delete=models.CASCADE)
     # The tag string, like "good problem".
     name = models.CharField(max_length=MAX_CHAR_FIELD_LENGTH, db_column='tag')
     # Materialized path. Always ends with ":".

--- a/tagstore/tagstore_rest/urls.py
+++ b/tagstore/tagstore_rest/urls.py
@@ -6,6 +6,8 @@ contain namespaces for the active versions of the API.
 """
 from django.conf.urls import url, include
 
+app_name = 'tagstore'
+
 urlpatterns = [
     url(r'^api/v1/', include('tagstore.tagstore_rest.v1.urls', namespace='apiv1')),
 ]

--- a/tagstore/tagstore_rest/v1/urls.py
+++ b/tagstore/tagstore_rest/v1/urls.py
@@ -7,6 +7,8 @@ from .views.entities import EntityViewSet
 
 root_router = EntityRouter()
 
+app_name = 'tagstore'
+
 root_router.register(r'entities', EntityViewSet)
 
 urlpatterns = [


### PR DESCRIPTION
## Description

This PR upgrades the Blockstore to use Python 3.8. As the project Django version only supported up to Python 3.7, Django has also been updated to match the version used by the LMS.

## Author Comments, Concerns, and Open Questions

This PR also removes the cache volume for the virtualenv. This volume probably made a lot of sense when the project began as developers needed to repeatedly blow away and recreate their devstack to make sure the build worked correctly, but they provide minimal benefit now and also will cause an issue if anyone upgrades in place, since their cached Python version will be incompatible.

## Test Instructions

Pull the changes, and then follow the new testing instructions in the README.

## Reviews
- [ ] @bradenmacdonald 
- [ ] edX reviewer TDB.
