### PR TITLE
Use edx-api-doc-tools instead of deprecated django-swagger

### DIFF
--- a/blockstore/settings/base.py
+++ b/blockstore/settings/base.py
@@ -39,9 +39,12 @@ INSTALLED_APPS = (
 )
 
 THIRD_PARTY_APPS = (
+    # API Documentation
+    'drf_yasg',
+    'edx_api_doc_tools',
+
     'rest_framework',
     'rest_framework.authtoken',  # For authenticating API clients
-    'rest_framework_swagger',
     'django_filters',
     'social_django',  # To let admin users log in using their LMS user account
     'waffle',

--- a/blockstore/urls.py
+++ b/blockstore/urls.py
@@ -19,23 +19,32 @@ from django.conf import settings
 from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.contrib import admin
-from rest_framework_swagger.views import get_swagger_view
+
+from edx_api_doc_tools import make_api_info, make_docs_urls
 
 from blockstore.apps.core import views as core_views
 from blockstore.apps.bundles.tests.storage_utils import url_for_test_media
 
 admin.autodiscover()
 
+api_info = make_api_info(
+    title="Blockstore API",
+    version="v1",
+    description="APIs for Openedx Blockstore"
+)
+
+
 urlpatterns = oauth2_urlpatterns + [
     url(r'^admin/', admin.site.urls),
     url(r'^api/', include('blockstore.apps.api.urls', namespace='api')),
-    url(r'^api-docs/', get_swagger_view(title='blockstore API')),
     # Use the same auth views for all logins, including those originating from the browseable API.
     url(r'^api-auth/', include((oauth2_urlpatterns, 'auth_backends'), namespace='rest_framework')),
     url(r'^auto_auth/$', core_views.AutoAuth.as_view(), name='auto_auth'),
     url(r'^health/$', core_views.health, name='health'),
     url(r'^tagstore/', include('tagstore.tagstore_rest.urls', namespace='tagstore')),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+
+urlpatterns += make_docs_urls(api_info)
 
 if settings.DEBUG:  # pragma: no cover
     import debug_toolbar

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -6,11 +6,11 @@ pyblake2
 django
 django-cors-headers
 django-environ
-django-rest-swagger
 django-waffle
 djangorestframework
 djangorestframework-expander
 django-filter
+edx-api-doc-tools
 edx-auth-backends
 edx-django-release-util
 mysqlclient

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,43 +5,47 @@
 #    make upgrade
 #
 attrs==18.2.0             # via -c requirements/constraints.txt, -r requirements/base.in
-certifi==2020.6.20        # via requests
+certifi==2020.11.8        # via requests
 cffi==1.14.3              # via cryptography
 chardet==3.0.4            # via requests
-coreapi==2.3.3            # via django-rest-swagger, openapi-codec
-coreschema==0.0.4         # via coreapi
-cryptography==3.1.1       # via social-auth-core
+coreapi==2.3.3            # via drf-yasg
+coreschema==0.0.4         # via coreapi, drf-yasg
+cryptography==3.2.1       # via social-auth-core
 defusedxml==0.6.0         # via python3-openid, social-auth-core
 django-cors-headers==2.2.1  # via -c requirements/constraints.txt, -r requirements/base.in
 django-environ==0.4.5     # via -c requirements/constraints.txt, -r requirements/base.in
 django-filter==2.1.0      # via -c requirements/constraints.txt, -r requirements/base.in
-django-rest-swagger==2.2.0  # via -r requirements/base.in
 django-waffle==2.0.0      # via -r requirements/base.in
-django==2.2.16            # via -c requirements/constraints.txt, -r requirements/base.in, django-filter, djangorestframework, drf-nested-routers, edx-auth-backends, edx-django-release-util
+django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.in, django-filter, djangorestframework, drf-nested-routers, drf-yasg, edx-api-doc-tools, edx-auth-backends, edx-django-release-util
 djangorestframework-expander==0.2.3  # via -r requirements/base.in
-djangorestframework==3.12.1  # via -r requirements/base.in, django-rest-swagger, djangorestframework-expander, drf-nested-routers
+djangorestframework==3.12.2  # via -r requirements/base.in, djangorestframework-expander, drf-nested-routers, drf-yasg, edx-api-doc-tools
 git+https://github.com/alanjds/drf-nested-routers.git@8686392f91b114e01f3781807dea60e9a80d3e07#egg=drf-nested-routers==0.91  # via -r requirements/github.in
+drf-yasg==1.20.0          # via edx-api-doc-tools
+edx-api-doc-tools==1.4.0  # via -r requirements/base.in
 edx-auth-backends==3.1.0  # via -r requirements/base.in
 edx-django-release-util==0.4.4  # via -r requirements/base.in
 idna==2.10                # via requests
+inflection==0.5.1         # via drf-yasg
 itypes==1.2.0             # via coreapi
 jinja2==2.11.2            # via coreschema
 markupsafe==1.1.1         # via jinja2
 mysqlclient==1.3.14       # via -c requirements/constraints.txt, -r requirements/base.in
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
-openapi-codec==1.3.2      # via django-rest-swagger
+packaging==20.4           # via drf-yasg
 pyblake2==1.1.2           # via -r requirements/base.in
 pycparser==2.20           # via cffi
 pyjwt==1.7.1              # via edx-auth-backends, social-auth-core
+pyparsing==2.4.7          # via packaging
 python3-openid==3.2.0     # via social-auth-core
-pytz==2020.1              # via -r requirements/base.in, django
+pytz==2020.4              # via -r requirements/base.in, django
 pyyaml==5.3.1             # via edx-django-release-util
 requests-oauthlib==1.3.0  # via social-auth-core
 requests==2.24.0          # via coreapi, requests-oauthlib, social-auth-core
-simplejson==3.17.2        # via django-rest-swagger
-six==1.15.0               # via cryptography, edx-auth-backends, edx-django-release-util, social-auth-app-django, social-auth-core
+ruamel.yaml.clib==0.2.2   # via ruamel.yaml
+ruamel.yaml==0.16.12      # via drf-yasg
+six==1.15.0               # via cryptography, edx-auth-backends, edx-django-release-util, packaging, social-auth-app-django, social-auth-core
 social-auth-app-django==4.0.0  # via edx-auth-backends
 social-auth-core==3.3.3   # via edx-auth-backends, social-auth-app-django
 sqlparse==0.4.1           # via -r requirements/base.in, django
-uritemplate==3.0.1        # via coreapi
-urllib3==1.25.10          # via requests
+uritemplate==3.0.1        # via coreapi, drf-yasg
+urllib3==1.25.11          # via requests

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -6,7 +6,7 @@
 #
 alabaster==0.7.12         # via sphinx
 babel==2.8.0              # via sphinx
-certifi==2020.6.20        # via requests
+certifi==2020.11.8        # via requests
 chardet==3.0.4            # via requests
 docutils==0.16            # via sphinx
 edx-sphinx-theme==1.5.0   # via -r requirements/docs.in
@@ -14,15 +14,15 @@ idna==2.10                # via requests
 imagesize==1.2.0          # via sphinx
 jinja2==2.11.2            # via sphinx
 markupsafe==1.1.1         # via jinja2
-pygments==2.7.1           # via sphinx
-pytz==2020.1              # via babel
+pygments==2.7.2           # via sphinx
+pytz==2020.4              # via babel
 requests==2.24.0          # via sphinx
 six==1.15.0               # via edx-sphinx-theme, sphinx
 snowballstemmer==2.0.0    # via sphinx
 sphinx==1.6.7             # via -r requirements/docs.in, edx-sphinx-theme
 sphinxcontrib-serializinghtml==1.1.4  # via sphinxcontrib-websupport
 sphinxcontrib-websupport==1.2.4  # via sphinx
-urllib3==1.25.10          # via requests
+urllib3==1.25.11          # via requests
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -8,15 +8,15 @@ alabaster==0.7.12         # via -r requirements/docs.txt, sphinx
 astroid==2.3.3            # via -r requirements/test.txt, pylint, pylint-celery
 attrs==18.2.0             # via -c requirements/constraints.txt, -r requirements/test.txt, pytest
 babel==2.8.0              # via -r requirements/docs.txt, sphinx
-certifi==2020.6.20        # via -r requirements/docs.txt, -r requirements/test.txt, requests
+certifi==2020.11.8        # via -r requirements/docs.txt, -r requirements/test.txt, requests
 cffi==1.14.3              # via -r requirements/test.txt, cryptography
 chardet==3.0.4            # via -r requirements/docs.txt, -r requirements/test.txt, requests
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
 click==7.1.2              # via -r requirements/test.txt, click-log, edx-lint
-coreapi==2.3.3            # via -r requirements/test.txt, django-rest-swagger, openapi-codec
-coreschema==0.0.4         # via -r requirements/test.txt, coreapi
+coreapi==2.3.3            # via -r requirements/test.txt, drf-yasg
+coreschema==0.0.4         # via -r requirements/test.txt, coreapi, drf-yasg
 coverage==5.3             # via -r requirements/test.txt, pytest-cov
-cryptography==3.1.1       # via -r requirements/test.txt, social-auth-core
+cryptography==3.2.1       # via -r requirements/test.txt, social-auth-core
 ddt==1.4.1                # via -r requirements/test.txt
 defusedxml==0.6.0         # via -r requirements/test.txt, python3-openid, social-auth-core
 diff-cover==4.0.1         # via -r requirements/test.txt
@@ -25,23 +25,25 @@ django-debug-toolbar==3.1.1  # via -r requirements/local.in
 django-dynamic-fixture==3.1.0  # via -r requirements/test.txt
 django-environ==0.4.5     # via -c requirements/constraints.txt, -r requirements/test.txt
 django-filter==2.1.0      # via -c requirements/constraints.txt, -r requirements/test.txt
-django-rest-swagger==2.2.0  # via -r requirements/test.txt
 django-waffle==2.0.0      # via -r requirements/test.txt
-django==2.2.16            # via -c requirements/constraints.txt, -r requirements/test.txt, django-debug-toolbar, django-filter, djangorestframework, drf-nested-routers, edx-auth-backends, edx-django-release-util
+django==2.2.17            # via -c requirements/constraints.txt, -r requirements/test.txt, django-debug-toolbar, django-filter, djangorestframework, drf-nested-routers, drf-yasg, edx-api-doc-tools, edx-auth-backends, edx-django-release-util
 djangorestframework-expander==0.2.3  # via -r requirements/test.txt
-djangorestframework==3.12.1  # via -r requirements/test.txt, django-rest-swagger, djangorestframework-expander, drf-nested-routers
+djangorestframework==3.12.2  # via -r requirements/test.txt, djangorestframework-expander, drf-nested-routers, drf-yasg, edx-api-doc-tools
 docutils==0.16            # via -r requirements/docs.txt, sphinx
 git+https://github.com/alanjds/drf-nested-routers.git@8686392f91b114e01f3781807dea60e9a80d3e07#egg=drf-nested-routers==0.91  # via -r requirements/test.txt
+drf-yasg==1.20.0          # via -r requirements/test.txt, edx-api-doc-tools
+edx-api-doc-tools==1.4.0  # via -r requirements/test.txt
 edx-auth-backends==3.1.0  # via -r requirements/test.txt
 edx-django-release-util==0.4.4  # via -r requirements/test.txt
 edx-lint==1.5.2           # via -r requirements/test.txt
 edx-sphinx-theme==1.5.0   # via -r requirements/docs.txt
 factory-boy==2.12.0       # via -c requirements/constraints.txt, -r requirements/test.txt
-faker==4.5.0              # via -r requirements/test.txt, factory-boy
+faker==4.14.2             # via -r requirements/test.txt, factory-boy
 idna==2.10                # via -r requirements/docs.txt, -r requirements/test.txt, requests
 imagesize==1.2.0          # via -r requirements/docs.txt, sphinx
 inflect==4.1.0            # via -r requirements/test.txt, jinja2-pluralize
-iniconfig==1.0.1          # via -r requirements/test.txt, pytest
+inflection==0.5.1         # via -r requirements/test.txt, drf-yasg
+iniconfig==1.1.1          # via -r requirements/test.txt, pytest
 isort==4.3.21             # via -r requirements/test.txt, pylint
 itypes==1.2.0             # via -r requirements/test.txt, coreapi
 jinja2-pluralize==0.3.0   # via -r requirements/test.txt, diff-cover
@@ -50,17 +52,16 @@ lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
 markupsafe==1.1.1         # via -r requirements/docs.txt, -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
 mypy-extensions==0.4.3    # via -r requirements/test.txt, mypy
-mypy==0.782               # via -r requirements/test.txt
+mypy==0.790               # via -r requirements/test.txt
 mysqlclient==1.3.14       # via -c requirements/constraints.txt, -r requirements/test.txt
 oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib, social-auth-core
-openapi-codec==1.3.2      # via -r requirements/test.txt, django-rest-swagger
-packaging==20.4           # via -r requirements/test.txt, pytest
+packaging==20.4           # via -r requirements/test.txt, drf-yasg, pytest
 pluggy==0.13.1            # via -r requirements/test.txt, diff-cover, pytest
 py==1.9.0                 # via -r requirements/test.txt, pytest
 pyblake2==1.1.2           # via -r requirements/test.txt
 pycodestyle==2.6.0        # via -r requirements/test.txt
 pycparser==2.20           # via -r requirements/test.txt, cffi
-pygments==2.7.1           # via -r requirements/docs.txt, -r requirements/test.txt, diff-cover, sphinx
+pygments==2.7.2           # via -r requirements/docs.txt, -r requirements/test.txt, diff-cover, sphinx
 pyjwt==1.7.1              # via -r requirements/test.txt, edx-auth-backends, social-auth-core
 pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
 pylint-django==2.0.11     # via -r requirements/test.txt, edx-lint
@@ -68,15 +69,16 @@ pylint-plugin-utils==0.6  # via -r requirements/test.txt, pylint-celery, pylint-
 pylint==2.4.4             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-cov==2.10.1        # via -r requirements/test.txt
-pytest-django==3.10.0     # via -r requirements/test.txt
-pytest==6.1.1             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest-django==4.1.0      # via -r requirements/test.txt
+pytest==6.1.2             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/test.txt, faker
 python3-openid==3.2.0     # via -r requirements/test.txt, social-auth-core
-pytz==2020.1              # via -r requirements/docs.txt, -r requirements/test.txt, babel, django
+pytz==2020.4              # via -r requirements/docs.txt, -r requirements/test.txt, babel, django
 pyyaml==5.3.1             # via -r requirements/test.txt, edx-django-release-util
 requests-oauthlib==1.3.0  # via -r requirements/test.txt, social-auth-core
 requests==2.24.0          # via -r requirements/docs.txt, -r requirements/test.txt, coreapi, requests-oauthlib, social-auth-core, sphinx
-simplejson==3.17.2        # via -r requirements/test.txt, django-rest-swagger
+ruamel.yaml.clib==0.2.2   # via -r requirements/test.txt, ruamel.yaml
+ruamel.yaml==0.16.12      # via -r requirements/test.txt, drf-yasg
 six==1.15.0               # via -r requirements/docs.txt, -r requirements/test.txt, astroid, cryptography, django-dynamic-fixture, edx-auth-backends, edx-django-release-util, edx-lint, edx-sphinx-theme, packaging, python-dateutil, social-auth-app-django, social-auth-core, sphinx
 snowballstemmer==2.0.0    # via -r requirements/docs.txt, sphinx
 social-auth-app-django==4.0.0  # via -r requirements/test.txt, edx-auth-backends
@@ -86,11 +88,11 @@ sphinxcontrib-serializinghtml==1.1.4  # via -r requirements/docs.txt, sphinxcont
 sphinxcontrib-websupport==1.2.4  # via -r requirements/docs.txt, sphinx
 sqlparse==0.4.1           # via -r requirements/test.txt, django, django-debug-toolbar
 text-unidecode==1.3       # via -r requirements/test.txt, faker
-toml==0.10.1              # via -r requirements/test.txt, pytest
+toml==0.10.2              # via -r requirements/test.txt, pytest
 typed-ast==1.4.1          # via -r requirements/test.txt, mypy
 typing-extensions==3.7.4.3  # via -r requirements/test.txt, mypy
-uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
-urllib3==1.25.10          # via -r requirements/docs.txt, -r requirements/test.txt, requests
+uritemplate==3.0.1        # via -r requirements/test.txt, coreapi, drf-yasg
+urllib3==1.25.11          # via -r requirements/docs.txt, -r requirements/test.txt, requests
 wrapt==1.11.2             # via -r requirements/test.txt, astroid
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -5,59 +5,63 @@
 #    make upgrade
 #
 attrs==18.2.0             # via -c requirements/constraints.txt, -r requirements/base.txt
-boto3==1.15.14            # via -c requirements/constraints.txt, -r requirements/production.in
-botocore==1.18.14         # via boto3, s3transfer
-certifi==2020.6.20        # via -r requirements/base.txt, requests
+boto3==1.16.14            # via -c requirements/constraints.txt, -r requirements/production.in
+botocore==1.19.14         # via boto3, s3transfer
+certifi==2020.11.8        # via -r requirements/base.txt, requests
 cffi==1.14.3              # via -r requirements/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, requests
-coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
-coreschema==0.0.4         # via -r requirements/base.txt, coreapi
-cryptography==3.1.1       # via -r requirements/base.txt, social-auth-core
+coreapi==2.3.3            # via -r requirements/base.txt, drf-yasg
+coreschema==0.0.4         # via -r requirements/base.txt, coreapi, drf-yasg
+cryptography==3.2.1       # via -r requirements/base.txt, social-auth-core
 defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core
 django-cors-headers==2.2.1  # via -c requirements/constraints.txt, -r requirements/base.txt
 django-environ==0.4.5     # via -c requirements/constraints.txt, -r requirements/base.txt
 django-filter==2.1.0      # via -c requirements/constraints.txt, -r requirements/base.txt
-django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-storages==1.10.1   # via -r requirements/production.in
 django-waffle==2.0.0      # via -r requirements/base.txt
-django==2.2.16            # via -c requirements/constraints.txt, -r requirements/base.txt, django-filter, django-storages, djangorestframework, drf-nested-routers, edx-auth-backends, edx-django-release-util
+django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.txt, django-filter, django-storages, djangorestframework, drf-nested-routers, drf-yasg, edx-api-doc-tools, edx-auth-backends, edx-django-release-util
 djangorestframework-expander==0.2.3  # via -r requirements/base.txt
-djangorestframework==3.12.1  # via -r requirements/base.txt, django-rest-swagger, djangorestframework-expander, drf-nested-routers
+djangorestframework==3.12.2  # via -r requirements/base.txt, djangorestframework-expander, drf-nested-routers, drf-yasg, edx-api-doc-tools
 git+https://github.com/alanjds/drf-nested-routers.git@8686392f91b114e01f3781807dea60e9a80d3e07#egg=drf-nested-routers==0.91  # via -r requirements/base.txt
+drf-yasg==1.20.0          # via -r requirements/base.txt, edx-api-doc-tools
+edx-api-doc-tools==1.4.0  # via -r requirements/base.txt
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/base.txt
 gevent==20.9.0            # via -r requirements/production.in
 greenlet==0.4.17          # via gevent
 gunicorn==20.0.4          # via -r requirements/production.in
 idna==2.10                # via -r requirements/base.txt, requests
+inflection==0.5.1         # via -r requirements/base.txt, drf-yasg
 itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, coreschema
 jmespath==0.10.0          # via boto3, botocore
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mysqlclient==1.3.14       # via -c requirements/constraints.txt, -r requirements/base.txt
-newrelic==5.20.1.150      # via -r requirements/production.in
+newrelic==5.22.1.152      # via -r requirements/production.in
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
-openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
+packaging==20.4           # via -r requirements/base.txt, drf-yasg
 pyblake2==1.1.2           # via -r requirements/base.txt
 pycparser==2.20           # via -r requirements/base.txt, cffi
 pyjwt==1.7.1              # via -r requirements/base.txt, edx-auth-backends, social-auth-core
+pyparsing==2.4.7          # via -r requirements/base.txt, packaging
 python-dateutil==2.8.1    # via botocore
 python-memcached==1.59    # via -r requirements/production.in
 python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
-pytz==2020.1              # via -r requirements/base.txt, django
+pytz==2020.4              # via -r requirements/base.txt, django
 pyyaml==5.3.1             # via -r requirements/base.txt, -r requirements/production.in, edx-django-release-util
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
 requests==2.24.0          # via -r requirements/base.txt, coreapi, requests-oauthlib, social-auth-core
+ruamel.yaml.clib==0.2.2   # via -r requirements/base.txt, ruamel.yaml
+ruamel.yaml==0.16.12      # via -r requirements/base.txt, drf-yasg
 s3transfer==0.3.3         # via boto3
-simplejson==3.17.2        # via -r requirements/base.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/base.txt, cryptography, edx-auth-backends, edx-django-release-util, python-dateutil, python-memcached, social-auth-app-django, social-auth-core
+six==1.15.0               # via -r requirements/base.txt, cryptography, edx-auth-backends, edx-django-release-util, packaging, python-dateutil, python-memcached, social-auth-app-django, social-auth-core
 social-auth-app-django==4.0.0  # via -r requirements/base.txt, edx-auth-backends
 social-auth-core==3.3.3   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.4.1           # via -r requirements/base.txt, django
-uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
-urllib3==1.25.10          # via -r requirements/base.txt, botocore, requests
+uritemplate==3.0.1        # via -r requirements/base.txt, coreapi, drf-yasg
+urllib3==1.25.11          # via -r requirements/base.txt, botocore, requests
 zope.event==4.5.0         # via gevent
-zope.interface==5.1.2     # via gevent
+zope.interface==5.2.0     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,15 +6,15 @@
 #
 astroid==2.3.3            # via -r requirements/test.in, pylint, pylint-celery
 attrs==18.2.0             # via -c requirements/constraints.txt, -r requirements/base.txt, pytest
-certifi==2020.6.20        # via -r requirements/base.txt, requests
+certifi==2020.11.8        # via -r requirements/base.txt, requests
 cffi==1.14.3              # via -r requirements/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint
-coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
-coreschema==0.0.4         # via -r requirements/base.txt, coreapi
+coreapi==2.3.3            # via -r requirements/base.txt, drf-yasg
+coreschema==0.0.4         # via -r requirements/base.txt, coreapi, drf-yasg
 coverage==5.3             # via -r requirements/test.in, pytest-cov
-cryptography==3.1.1       # via -r requirements/base.txt, social-auth-core
+cryptography==3.2.1       # via -r requirements/base.txt, social-auth-core
 ddt==1.4.1                # via -r requirements/test.in
 defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core
 diff-cover==4.0.1         # via -r requirements/test.in
@@ -22,20 +22,22 @@ django-cors-headers==2.2.1  # via -c requirements/constraints.txt, -r requiremen
 django-dynamic-fixture==3.1.0  # via -r requirements/test.in
 django-environ==0.4.5     # via -c requirements/constraints.txt, -r requirements/base.txt
 django-filter==2.1.0      # via -c requirements/constraints.txt, -r requirements/base.txt
-django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-waffle==2.0.0      # via -r requirements/base.txt
-django==2.2.16            # via -c requirements/constraints.txt, -r requirements/base.txt, django-filter, djangorestframework, drf-nested-routers, edx-auth-backends, edx-django-release-util
+django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.txt, django-filter, djangorestframework, drf-nested-routers, drf-yasg, edx-api-doc-tools, edx-auth-backends, edx-django-release-util
 djangorestframework-expander==0.2.3  # via -r requirements/base.txt
-djangorestframework==3.12.1  # via -r requirements/base.txt, django-rest-swagger, djangorestframework-expander, drf-nested-routers
+djangorestframework==3.12.2  # via -r requirements/base.txt, djangorestframework-expander, drf-nested-routers, drf-yasg, edx-api-doc-tools
 git+https://github.com/alanjds/drf-nested-routers.git@8686392f91b114e01f3781807dea60e9a80d3e07#egg=drf-nested-routers==0.91  # via -r requirements/base.txt
+drf-yasg==1.20.0          # via -r requirements/base.txt, edx-api-doc-tools
+edx-api-doc-tools==1.4.0  # via -r requirements/base.txt
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/base.txt
 edx-lint==1.5.2           # via -r requirements/test.in
 factory-boy==2.12.0       # via -c requirements/constraints.txt, -r requirements/test.in
-faker==4.5.0              # via factory-boy
+faker==4.14.2             # via factory-boy
 idna==2.10                # via -r requirements/base.txt, requests
 inflect==4.1.0            # via jinja2-pluralize
-iniconfig==1.0.1          # via pytest
+inflection==0.5.1         # via -r requirements/base.txt, drf-yasg
+iniconfig==1.1.1          # via pytest
 isort==4.3.21             # via pylint
 itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2-pluralize==0.3.0   # via diff-cover
@@ -44,41 +46,41 @@ lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mccabe==0.6.1             # via pylint
 mypy-extensions==0.4.3    # via mypy
-mypy==0.782               # via -r requirements/test.in
+mypy==0.790               # via -r requirements/test.in
 mysqlclient==1.3.14       # via -c requirements/constraints.txt, -r requirements/base.txt
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
-openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
-packaging==20.4           # via pytest
+packaging==20.4           # via -r requirements/base.txt, drf-yasg, pytest
 pluggy==0.13.1            # via diff-cover, pytest
 py==1.9.0                 # via pytest
 pyblake2==1.1.2           # via -r requirements/base.txt
 pycodestyle==2.6.0        # via -r requirements/test.in
 pycparser==2.20           # via -r requirements/base.txt, cffi
-pygments==2.7.1           # via diff-cover
+pygments==2.7.2           # via diff-cover
 pyjwt==1.7.1              # via -r requirements/base.txt, edx-auth-backends, social-auth-core
 pylint-celery==0.3        # via edx-lint
 pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pyparsing==2.4.7          # via packaging
+pyparsing==2.4.7          # via -r requirements/base.txt, packaging
 pytest-cov==2.10.1        # via -r requirements/test.in
-pytest-django==3.10.0     # via -r requirements/test.in
-pytest==6.1.1             # via -r requirements/test.in, pytest-cov, pytest-django
+pytest-django==4.1.0      # via -r requirements/test.in
+pytest==6.1.2             # via -r requirements/test.in, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via faker
 python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
-pytz==2020.1              # via -r requirements/base.txt, django
+pytz==2020.4              # via -r requirements/base.txt, django
 pyyaml==5.3.1             # via -r requirements/base.txt, edx-django-release-util
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
 requests==2.24.0          # via -r requirements/base.txt, coreapi, requests-oauthlib, social-auth-core
-simplejson==3.17.2        # via -r requirements/base.txt, django-rest-swagger
+ruamel.yaml.clib==0.2.2   # via -r requirements/base.txt, ruamel.yaml
+ruamel.yaml==0.16.12      # via -r requirements/base.txt, drf-yasg
 six==1.15.0               # via -r requirements/base.txt, astroid, cryptography, django-dynamic-fixture, edx-auth-backends, edx-django-release-util, edx-lint, packaging, python-dateutil, social-auth-app-django, social-auth-core
 social-auth-app-django==4.0.0  # via -r requirements/base.txt, edx-auth-backends
 social-auth-core==3.3.3   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.4.1           # via -r requirements/base.txt, django
 text-unidecode==1.3       # via faker
-toml==0.10.1              # via pytest
+toml==0.10.2              # via pytest
 typed-ast==1.4.1          # via mypy
 typing-extensions==3.7.4.3  # via mypy
-uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
-urllib3==1.25.10          # via -r requirements/base.txt, requests
+uritemplate==3.0.1        # via -r requirements/base.txt, coreapi, drf-yasg
+urllib3==1.25.11          # via -r requirements/base.txt, requests
 wrapt==1.11.2             # via astroid


### PR DESCRIPTION
## Description

This PR adds the changes to use edx-api-doc-tools instead of django-swagger

## Author Comments, Concerns, and Open Questions

As I mentioned in another PR, this [will only display](https://github.com/edx/api-doc-tools/issues/27) in  /api-docs/ the APIs that are in the /api/ path (it will not display the tagstore APIs),

## Test Instructions
Run the server and go to the /api-docs/, that should look like this:


![image](https://user-images.githubusercontent.com/22335041/93230556-c9488a80-f745-11ea-80ae-2ad2a21ac2a7.png)

## TODOs
If anything isn't yet done, list it here
- [ ] Squash before merging
