### PR TITLE
[WIP] Adds new BundleVersion endpoint for file path redirect

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,10 @@ Prerequisite: Have your Open edX `Devstack <https://github.com/edx/devstack>`_ p
 
    To use Blockstore library content in a course, open your course in Studio. In its advanced settings, add ``library_sourced`` to the list of "advanced block types". In the "Unit Edit View" in Studio, find the green "Add New Component" buttons. Click Advanced > Library Sourced Content. Edit the new Library Sourced Content XBlock to enter the XBlock ID of the library content that you'd like to use. It should be similar to ``lb:DeveloperInc:MyLibrary:1`` (note: ``lb:`` is short for "Library Block" and should not be confused with the ``lib:`` prefix used to identify a library).
 
+#. Optional: If you want to override some settings, the easiest alternative is to create and populate the `private.py` settings file:
+
+   #. Copy ``blockstore/settings/private.py.example`` to ``blockstore/settings/private.py``
+
 #. Optional: To log in to Blockstore in your web browser directly, you'll need to configure SSO with your devstack. Most people won't need to do this, but it's helpful for debugging or development.
 
    #. Go to http://localhost:18000/admin/oauth2_provider/application/ and add a new application
@@ -69,10 +73,17 @@ Prerequisite: Have your Open edX `Devstack <https://github.com/edx/devstack>`_ p
    #. Press "Save and continue editing"
    #. Go to http://localhost:18000/admin/oauth_dispatch/applicationaccess/
    #. Click "Add Application Access +", choose Application: ``blockstore-sso`` and set Scopes to ``user_id``, then hit "Save"
-   #. Copy ``blockstore/settings/private.py.example`` to ``blockstore/settings/private.py``
    #. In ``private.py``, set ``SOCIAL_AUTH_EDX_OAUTH2_SECRET`` to the random "Client secret" value.
    #. Now you can login at http://localhost:18250/login/
 
+#. Optional: You can also setup S3 as the storage backend with devstack. In ``private.py`` set the following variables:
+
+   .. code::
+
+      DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
+      AWS_ACCESS_KEY_ID = "SET_YOUR_OWN_ACCESS_KEY"
+      AWS_SECRET_ACCESS_KEY = "SET_YOUR_OWN_SECRET_KEY"
+      AWS_STORAGE_BUCKET_NAME = "blockstore-bucket-example"
 
 Running Tests
 =============

--- a/blockstore/apps/api/v1/serializers/bundles.py
+++ b/blockstore/apps/api/v1/serializers/bundles.py
@@ -7,7 +7,6 @@ from rest_framework.relations import SlugRelatedField
 from rest_framework.reverse import reverse
 
 from blockstore.apps.bundles.models import Bundle, BundleVersion, Collection
-from blockstore.apps.bundles.store import SnapshotRepo
 from ... import relations
 
 
@@ -125,12 +124,6 @@ class BundleVersionWithFileDataSerializer(BundleVersionSerializer):
 
     class SnapshotField(serializers.Field):
         """Helper read-only field for a Snapshot."""
-        def _serialized_dep(self, dependency):
-            return {
-                "bundle_uuid": dependency.bundle_uuid,
-                "version": dependency.version,
-                "snapshot_digest": dependency.snapshot_digest.hex(),
-            }
 
         def _expand_url(self, url):
             """Ensure that the given URL is an absolute URL"""
@@ -140,33 +133,13 @@ class BundleVersionWithFileDataSerializer(BundleVersionSerializer):
 
         def to_representation(self, value):
             """Snapshot JSON serialization."""
-            snapshot = value
-            snapshot_repo = SnapshotRepo()
-            info = {
-                'hash_digest': snapshot.hash_digest.hex(),
-                'created_at': snapshot.created_at,
-            }
-
-            info['files'] = {
-                path: {
-                    "url": self._expand_url(snapshot_repo.url(snapshot, path)),
-                    "size": file_info.size,
-                    "hash_digest": file_info.hash_digest.hex(),
-                }
-                for path, file_info in snapshot.files.items()
-            }
-
-            info['links'] = {
-                link.name: {
-                    "direct": self._serialized_dep(link.direct_dependency),
-                    "indirect": [
-                        self._serialized_dep(dep)
-                        for dep in link.indirect_dependencies
-                    ]
-                }
-                for link in snapshot.links
-            }
-
+            view_kwargs = self.context['view'].kwargs
+            info = value.serialize(context=self.context)
+            for file_name, file_info in info['files'].items():
+                file_info['url'] = self._expand_url('{}?file={}'.format(
+                    reverse('api:v1:bundleversion-redirect', kwargs=view_kwargs),
+                    file_name,
+                ))
             return info
 
         def to_internal_value(self, _data):

--- a/blockstore/apps/api/v1/tests/test_contract.py
+++ b/blockstore/apps/api/v1/tests/test_contract.py
@@ -45,6 +45,7 @@ class ApiTestCase(TestCase):
     def setUp(self):
         super().setUp()
         self.client = APIClient()
+        self.public_client = APIClient()
         # Authenticate (this can't be done via the REST API for security reasons)
         test_user = User.objects.create(username='test-service-user')
         token = Token.objects.create(user=test_user)
@@ -294,7 +295,7 @@ class BundleVersionsTestCase(ApiTestCase):
         assert parsed_url.path == url
         assert dict(parse_qsl(parsed_url.query))['file'] == 'hello.txt'
 
-        redirect_response = self.client.get(parsed_url.geturl())
+        redirect_response = self.public_client.get(parsed_url.geturl())
         assert redirect_response.status_code == 303
         assert redirect_response.url
 
@@ -384,7 +385,7 @@ class DraftsTest(ApiTestCase):
         )
         file_url = bundle_version_detail_data['snapshot']['files']['hello.txt']['url']
         assert file_url.startswith('http'), "Response URLs should be absolute"
-        file_response = self.client.get(file_url, follow=True)
+        file_response = self.public_client.get(file_url, follow=True)
         assert response_str_file(file_response) == "Hello World! 😀"
 
     def test_editing_errors(self):
@@ -446,7 +447,7 @@ class DraftsTest(ApiTestCase):
         for file_name in draft_files:
             print(draft_files[file_name]['url'])
             print(snapshot_files[file_name]['url'])
-            assert draft_files[file_name]['url'] == self.client.get(snapshot_files[file_name]['url']).url
+            assert draft_files[file_name]['url'] == self.public_client.get(snapshot_files[file_name]['url']).url
             assert draft_files[file_name]['size'] == snapshot_files[file_name]['size']
             assert draft_files[file_name]['hash_digest'] == snapshot_files[file_name]['hash_digest']
             assert draft_files[file_name]['modified'] is False
@@ -476,11 +477,11 @@ class DraftsTest(ApiTestCase):
         snapshot_files = bundle_version_data['snapshot']['files']
         assert 'empty.txt' not in snapshot_files  # Was deleted
         hawaii_text = response_str_file(
-            self.client.get(snapshot_files['hawaii.txt']['url'], follow=True)
+            self.public_client.get(snapshot_files['hawaii.txt']['url'], follow=True)
         )
         assert hawaii_text == "Aloha a hui hou!"
         korea_text = response_str_file(
-            self.client.get(snapshot_files['korea.txt']['url'], follow=True)
+            self.public_client.get(snapshot_files['korea.txt']['url'], follow=True)
         )
         assert korea_text == "안녕하세요!"
 

--- a/blockstore/apps/api/v1/tests/test_contract.py
+++ b/blockstore/apps/api/v1/tests/test_contract.py
@@ -288,14 +288,13 @@ class BundleVersionsTestCase(ApiTestCase):
         response_redirect_url = detail_data['snapshot']['files']['hello.txt']['url']
         parsed_url = urlparse(response_redirect_url)._replace(netloc='', scheme='')
 
-        url = reverse(
-            "api:v1:bundleversion-redirect",
-            kwargs={"bundle_uuid": draft_data['bundle_uuid'], 'version_num': 1},
+        assert parsed_url.path == '/api/v1/bundle_versions/{bundle_uuid},{version_num}/redirect'.format(
+            bundle_uuid=draft_data['bundle_uuid'],
+            version_num=1,
         )
-        assert parsed_url.path == url
         assert dict(parse_qsl(parsed_url.query))['file'] == 'hello.txt'
 
-        redirect_response = self.public_client.get(parsed_url.geturl())
+        redirect_response = self.public_client.get(response_redirect_url)
         assert redirect_response.status_code == 303
         assert redirect_response.url
 
@@ -445,8 +444,6 @@ class DraftsTest(ApiTestCase):
 
         assert updated_draft_data['staged_draft']['base_snapshot'] == bundle_version_data['snapshot']['hash_digest']
         for file_name in draft_files:
-            print(draft_files[file_name]['url'])
-            print(snapshot_files[file_name]['url'])
             assert draft_files[file_name]['url'] == self.public_client.get(snapshot_files[file_name]['url']).url
             assert draft_files[file_name]['size'] == snapshot_files[file_name]['size']
             assert draft_files[file_name]['hash_digest'] == snapshot_files[file_name]['hash_digest']

--- a/blockstore/apps/api/v1/views/bundles.py
+++ b/blockstore/apps/api/v1/views/bundles.py
@@ -113,6 +113,8 @@ class BundleVersionViewSet(mixins.UpdateModelMixin, viewsets.ReadOnlyModelViewSe
     def redirect(self, request, *args, **kwargs):
         """
         Redirect a BundleVersion file path to the actual file.
+
+        Check <decisions/0003-bundle-versions-redirect.rst> for more context.
         """
         instance = self.get_object()
         snapshot = instance.snapshot()

--- a/blockstore/apps/api/v1/views/bundles.py
+++ b/blockstore/apps/api/v1/views/bundles.py
@@ -15,7 +15,12 @@ from rest_framework.permissions import AllowAny
 from blockstore.apps.bundles.models import Bundle, BundleVersion
 
 from ...constants import UUID4_REGEX, VERSION_NUM_REGEX
-from ..serializers.bundles import BundleSerializer, BundleVersionSerializer, BundleVersionWithFileDataSerializer
+from ..serializers.bundles import (
+    BundleSerializer,
+    BundleVersionSerializer,
+    BundleVersionWithFileDataSerializer,
+    SnapshotSerializer,
+)
 
 
 class BundleFilter(FilterSet):
@@ -118,7 +123,7 @@ class BundleVersionViewSet(mixins.UpdateModelMixin, viewsets.ReadOnlyModelViewSe
         """
         instance = self.get_object()
         snapshot = instance.snapshot()
-        serialized_snapshot = snapshot.serialize(context={'request': request})
+        serialized_snapshot = SnapshotSerializer(snapshot, context={'request': request}).data
 
         filename = request.query_params.get('file')
         if not filename:

--- a/blockstore/apps/api/v1/views/bundles.py
+++ b/blockstore/apps/api/v1/views/bundles.py
@@ -10,6 +10,7 @@ from django_filters.rest_framework import DjangoFilterBackend, FilterSet
 from rest_framework import viewsets, mixins, serializers
 from rest_framework.decorators import action
 from rest_framework.generics import get_object_or_404
+from rest_framework.permissions import AllowAny
 
 from blockstore.apps.bundles.models import Bundle, BundleVersion
 
@@ -70,6 +71,16 @@ class BundleVersionViewSet(mixins.UpdateModelMixin, viewsets.ReadOnlyModelViewSe
     filterset_fields = ('bundle__uuid', 'bundle__collection__uuid')
 
     queryset = BundleVersion.objects.all().select_related('bundle')
+
+    permission_classes_by_action = {
+        'redirect': (AllowAny,)
+    }
+
+    def get_permissions(self):
+        try:
+            return [permission() for permission in self.permission_classes_by_action[self.action]]
+        except KeyError:
+            return super(BundleVersionViewSet, self).get_permissions()
 
     def get_object(self):
         queryset = self.filter_queryset(self.get_queryset())

--- a/blockstore/apps/bundles/store.py
+++ b/blockstore/apps/bundles/store.py
@@ -121,49 +121,6 @@ class Snapshot:
             created_at=created_at,
         )
 
-    def _serialized_dep(self, dependency):
-        return {
-            "bundle_uuid": dependency.bundle_uuid,
-            "version": dependency.version,
-            "snapshot_digest": dependency.snapshot_digest.hex(),
-        }
-
-    def _expand_url(self, url, context):
-        """Ensure that the given URL is an absolute URL"""
-        if not url.startswith('http'):
-            url = context['request'].build_absolute_uri(url)
-        return url
-
-    def serialize(self, context):
-        """Serialize a snapshot."""
-        snapshot_repo = SnapshotRepo()
-        info = {
-            'hash_digest': self.hash_digest.hex(),
-            'created_at': self.created_at,
-        }
-
-        info['files'] = {
-            path: {
-                "url": self._expand_url(snapshot_repo.url(self, path), context),
-                "size": file_info.size,
-                "hash_digest": file_info.hash_digest.hex(),
-            }
-            for path, file_info in self.files.items()
-        }
-
-        info['links'] = {
-            link.name: {
-                "direct": self._serialized_dep(link.direct_dependency),
-                "indirect": [
-                    self._serialized_dep(dep)
-                    for dep in link.indirect_dependencies
-                ]
-            }
-            for link in self.links
-        }
-
-        return info
-
     class NotFoundError(Exception):
         pass
 

--- a/decisions/0002-app-not-service.rst
+++ b/decisions/0002-app-not-service.rst
@@ -20,7 +20,7 @@ Rationale
 
 Domain Driven Design
 --------------------
-Blockstore is a new peristence mechanism for Studio and is an implementation detail of the Content Authoring domain. Blockstore should continue to be strongly separated from a logic/code point of view, and maintain its place as something that is XBlock-agnostic.
+Blockstore is a new persistence mechanism for Studio and is an implementation detail of the Content Authoring domain. Blockstore should continue to be strongly separated from a logic/code point of view, and maintain its place as something that is XBlock-agnostic.
 
 Development and Deployment
 --------------------------
@@ -40,4 +40,4 @@ Early visions of Blockstore speculated a future where one Blockstore instance ha
 
 Reversibility
 -------------
-Blockstore is still separate app in a separate repo, with its own REST API. As long as it maintains its separation from the XBlock runtime (made easier by being in a different repo), we should be able to exract it back out into a service if makes sense to do so in the future.
+Blockstore is still separate app in a separate repo, with its own REST API. As long as it maintains its separation from the XBlock runtime (made easier by being in a different repo), we should be able to extract it back out into a service if makes sense to do so in the future.

--- a/decisions/0003-bundle-versions-redirect.rst
+++ b/decisions/0003-bundle-versions-redirect.rst
@@ -7,13 +7,13 @@ Problem
 -------
 
 Bundle Versions are stored as files using django's storage backend, and for this it's very common to use
-AWS S3 (used by Open edX that way). As Blockstore can be used as an API, it's usual for clients to cache
-these file urls, which could result in expired urls in the case of S3.
+AWS S3 (used by Open edX that way). To allow the content owner to control access to these files, most object
+storage providers encourage or enforce the use of signed URLs that expire after a predetermined amount of time.
 
 --------
 Decision
 --------
 
-The BundleVersion endpoints should return bundle information as normal but instead of returning the bundle
+The BundleVersion endpoints should return bundle information as normal but instead of returning the direct
 file path url, return a link to a new Blockstore endpoint that will redirect to the actual file path, making
 the urls returned by our API always usable.

--- a/decisions/0003-bundle-versions-redirect.rst
+++ b/decisions/0003-bundle-versions-redirect.rst
@@ -1,0 +1,19 @@
+========================================================================
+Bundle Version pointing to redirect endpoint instead of direct file path
+========================================================================
+
+-------
+Problem
+-------
+
+Bundle Versions are stored as files using django's storage backend, and for this it's very common to use
+AWS S3 (used by Open edX that way). As Blockstore can be used as an API, it's usual for clients to cache
+these file urls, which could result in expired urls in the case of S3.
+
+--------
+Decision
+--------
+
+The BundleVersion endpoints should return bundle information as normal but instead of returning the bundle
+file path url, return a link to a new Blockstore endpoint that will redirect to the actual file path, making
+the urls returned by our API always usable.

--- a/requirements/local.in
+++ b/requirements/local.in
@@ -1,7 +1,7 @@
--c constraints.txt
+-r constraints.txt
 
 # Packages required for local development
 -r test.txt
 -r docs.txt
 
-django-debug-toolbar
+django-debug-toolbar<3.0

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -6,8 +6,10 @@
 #
 alabaster==0.7.12         # via -r requirements/docs.txt, sphinx
 astroid==2.3.3            # via -r requirements/test.txt, pylint, pylint-celery
-attrs==18.2.0             # via -c requirements/constraints.txt, -r requirements/test.txt, pytest
+attrs==18.2.0             # via -r requirements/constraints.txt, -r requirements/test.txt, pytest
 babel==2.8.0              # via -r requirements/docs.txt, sphinx
+boto3==1.15.6             # via -r requirements/constraints.txt
+botocore==1.18.6          # via boto3, s3transfer
 certifi==2020.6.20        # via -r requirements/docs.txt, -r requirements/test.txt, requests
 cffi==1.14.2              # via -r requirements/test.txt, cryptography
 chardet==3.0.4            # via -r requirements/docs.txt, -r requirements/test.txt, requests
@@ -20,14 +22,15 @@ cryptography==3.1         # via -r requirements/test.txt, social-auth-core
 ddt==1.4.1                # via -r requirements/test.txt
 defusedxml==0.6.0         # via -r requirements/test.txt, python3-openid, social-auth-core
 diff-cover==4.0.0         # via -r requirements/test.txt
-django-cors-headers==2.2.1  # via -c requirements/constraints.txt, -r requirements/test.txt
+django-cors-headers==2.2.1  # via -r requirements/constraints.txt, -r requirements/test.txt
 django-debug-toolbar==2.2  # via -r requirements/local.in
 django-dynamic-fixture==3.1.0  # via -r requirements/test.txt
-django-environ==0.4.5     # via -c requirements/constraints.txt, -r requirements/test.txt
-django-filter==2.1.0      # via -c requirements/constraints.txt, -r requirements/test.txt
+django-environ==0.4.5     # via -r requirements/constraints.txt, -r requirements/test.txt
+django-filter==2.1.0      # via -r requirements/constraints.txt, -r requirements/test.txt
 django-rest-swagger==2.2.0  # via -r requirements/test.txt
-django-waffle==0.18.0     # via -c requirements/constraints.txt, -r requirements/test.txt
-django==2.2.16            # via -c requirements/constraints.txt, -r requirements/test.txt, django-debug-toolbar, django-filter, djangorestframework, drf-nested-routers, edx-auth-backends, edx-django-release-util
+django-storages==1.9.1    # via -r requirements/constraints.txt
+django-waffle==0.18.0     # via -r requirements/constraints.txt, -r requirements/test.txt
+django==2.2.16            # via -r requirements/constraints.txt, -r requirements/test.txt, django-debug-toolbar, django-filter, django-storages, djangorestframework, drf-nested-routers, edx-auth-backends, edx-django-release-util
 djangorestframework-expander==0.2.3  # via -r requirements/test.txt
 djangorestframework==3.11.1  # via -r requirements/test.txt, django-rest-swagger, djangorestframework-expander, drf-nested-routers
 docutils==0.16            # via -r requirements/docs.txt, sphinx
@@ -36,7 +39,7 @@ edx-auth-backends==3.1.0  # via -r requirements/test.txt
 edx-django-release-util==0.4.4  # via -r requirements/test.txt
 edx-lint==1.5.2           # via -r requirements/test.txt
 edx-sphinx-theme==1.5.0   # via -r requirements/docs.txt
-factory-boy==2.12.0       # via -c requirements/constraints.txt, -r requirements/test.txt
+factory-boy==2.12.0       # via -r requirements/constraints.txt, -r requirements/test.txt
 faker==4.1.3              # via -r requirements/test.txt, factory-boy
 idna==2.10                # via -r requirements/docs.txt, -r requirements/test.txt, requests
 imagesize==1.2.0          # via -r requirements/docs.txt, sphinx
@@ -47,6 +50,7 @@ isort==4.3.21             # via -r requirements/test.txt, pylint
 itypes==1.2.0             # via -r requirements/test.txt, coreapi
 jinja2-pluralize==0.3.0   # via -r requirements/test.txt, diff-cover
 jinja2==2.11.2            # via -r requirements/docs.txt, -r requirements/test.txt, coreschema, diff-cover, jinja2-pluralize, sphinx
+jmespath==0.10.0          # via boto3, botocore
 lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
 markupsafe==1.1.1         # via -r requirements/docs.txt, -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
@@ -54,7 +58,7 @@ mock==3.0.5               # via -r requirements/test.txt
 more-itertools==8.5.0     # via -r requirements/test.txt, pytest
 mypy-extensions==0.4.3    # via -r requirements/test.txt, mypy
 mypy==0.782               # via -r requirements/test.txt
-mysqlclient==1.3.14       # via -c requirements/constraints.txt, -r requirements/test.txt
+mysqlclient==1.3.14       # via -r requirements/constraints.txt, -r requirements/test.txt
 oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/test.txt, django-rest-swagger
 packaging==20.4           # via -r requirements/test.txt, pytest
@@ -74,12 +78,13 @@ pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-cov==2.10.1        # via -r requirements/test.txt
 pytest-django==3.10.0     # via -r requirements/test.txt
 pytest==6.0.2             # via -r requirements/test.txt, pytest-cov, pytest-django
-python-dateutil==2.8.1    # via -r requirements/test.txt, faker
+python-dateutil==2.8.1    # via -r requirements/test.txt, botocore, faker
 python3-openid==3.2.0     # via -r requirements/test.txt, social-auth-core
 pytz==2020.1              # via -r requirements/docs.txt, -r requirements/test.txt, babel, django
 pyyaml==5.3.1             # via -r requirements/test.txt, edx-django-release-util
 requests-oauthlib==1.3.0  # via -r requirements/test.txt, social-auth-core
 requests==2.24.0          # via -r requirements/docs.txt, -r requirements/test.txt, coreapi, requests-oauthlib, social-auth-core, sphinx
+s3transfer==0.3.3         # via boto3
 simplejson==3.17.2        # via -r requirements/test.txt, django-rest-swagger
 six==1.15.0               # via -r requirements/docs.txt, -r requirements/test.txt, astroid, cryptography, django-dynamic-fixture, edx-auth-backends, edx-django-release-util, edx-lint, edx-sphinx-theme, mock, packaging, pathlib2, python-dateutil, social-auth-app-django, social-auth-core, sphinx
 snowballstemmer==2.0.0    # via -r requirements/docs.txt, sphinx
@@ -94,7 +99,7 @@ toml==0.10.1              # via -r requirements/test.txt, pytest
 typed-ast==1.4.1          # via -r requirements/test.txt, astroid, mypy
 typing-extensions==3.7.4.3  # via -r requirements/test.txt, mypy
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
-urllib3==1.25.10          # via -r requirements/docs.txt, -r requirements/test.txt, requests
+urllib3==1.25.10          # via -r requirements/docs.txt, -r requirements/test.txt, botocore, requests
 wrapt==1.11.2             # via -r requirements/test.txt, astroid
 zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata
 


### PR DESCRIPTION
## Description

LX is presenting a problem of S3 BundleVersions file paths being expired:

    The provided token has expired.

The idea is for blockstore to retrieve file paths to blockstore itself that then redirects to the actual file path

## Test Instructions

Tests included, just run:

    make test

Reviewers:
[ ] @bradenmacdonald 
[ ] @arbrandes
[ ] TBD