### PR TITLE
Support multiple Open edX devstacks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,11 @@ Prerequisite: Have your Open edX `Devstack <https://github.com/edx/devstack>`_ p
    #. In ``private.py``, set ``SOCIAL_AUTH_EDX_OAUTH2_SECRET`` to the random "Client secret" value.
    #. Now you can login at http://localhost:18250/login/
 
+#. Optional: If running an Open edX devstack under a project name different
+   than the default (support for which was introduced
+   [here](https://github.com/edx/devstack/pull/532)), simply export
+   ``OPENEDX_PROJECT_NAME`` and substitute the container names in the commands
+   above accordingly.
 
 Running Tests
 =============

--- a/docker-compose-3.8.yml
+++ b/docker-compose-3.8.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
 
   blockstore:
-    container_name: edx.devstack.blockstore
+    container_name: edx.${OPENEDX_PROJECT_NAME:-devstack}.blockstore
     image: opencraft/blockstore:latest
     build:
       context: .
@@ -12,8 +12,10 @@ services:
     tty: true
     entrypoint: ["/bin/bash"]
     networks:
-      - default
-      - devstack
+      default:
+      devstack:
+        aliases:
+          - edx.devstack.blockstore
     ports:
       - "18250:18250"
     volumes:
@@ -29,7 +31,7 @@ services:
 networks:
   devstack:
     external:
-      name: devstack_default
+      name: ${OPENEDX_PROJECT_NAME:-devstack}_default
 
 volumes:
   blockstore_venv_3_8_5:

--- a/docker-compose-testserver-3.8.yml
+++ b/docker-compose-testserver-3.8.yml
@@ -6,7 +6,7 @@ version: '3'
 services:
 
   blockstore:
-    container_name: edx.devstack.blockstore-test
+    container_name: edx.${OPENEDX_PROJECT_NAME:-devstack}.blockstore-test
     image: opencraft/blockstore:latest
     build:
       context: .
@@ -15,8 +15,10 @@ services:
     tty: true
     entrypoint: ["/bin/bash"]
     networks:
-      - default
-      - devstack
+      default:
+      devstack:
+        aliases:
+          - edx.devstack.blockstore-test
     ports:
       - "18251:18251"
     volumes:
@@ -32,7 +34,7 @@ services:
 networks:
   devstack:
     external:
-      name: devstack_default
+      name: ${OPENEDX_PROJECT_NAME:-devstack}_default
 
 volumes:
   blockstore_venv_3_8_5:


### PR DESCRIPTION
## Description

This allows for multiple edX devstacks (introduced via https://github.com/edx/devstack/pull/532) by letting the user specify which compose project to target.

It also adds a couple of convenience Makefile targets.

## Test Instructions

For the simplest test, pulling in this PR should not affect the maintenance of an existing devstack, or creating a new one as usual.

To actually test the feature introduced here, one must first create a new Open edX devstack using a separate compose project.  See [the instructions in the README](https://github.com/edx/devstack/blob/master/README.rst#how-do-i-run-multiple-named-open-edx-releases-on-same-machine).  Then, export OPENEDX_PROJECT_NAME accordingly and check if blockstore provisions and runs correctly.