### PR TITLE
Fix `make stop` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,8 @@ dev.provision:  # Provision Blockstore service
 	docker exec -t ${CONTAINER_NAME} /bin/bash -c 'source ~/.bashrc && make requirements && make migrate'
 
 stop:  # Stop Blockstore container
-	docker-compose --project-name blockstore -f docker-compose.yml stop
+	docker-compose --project-name "blockstore${PYTHON_VERSION}" -f "docker-compose-${PYTHON_VERSION}.yml" stop
+	docker-compose --project-name "blockstore-testserver${PYTHON_VERSION}" -f "docker-compose-testserver-${PYTHON_VERSION}.yml" stop
 
 pull:  # Update docker images that this depends on.
 	docker pull python:3.8.5-alpine3.12


### PR DESCRIPTION
This was broken since the docker-compose filename now includes
the PYTHON_VERSION variable.
This fixes by using the same project names and docker compose file names
as used in the other commands.

**Jira tickets**: [OSPR-5081](https://openedx.atlassian.net/browse/OSPR-5081)

**Test instructions**:

Run `make stop` and verify that it completes successfully.

**Reviewers**:

- [ ] TBD
- [ ] edX reviewer TBD
