### PR TITLE
[TNL-7642] [SE-3536] Switch MySQL backends to 5.7.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
     working_directory: /blockstore/app/
     docker:
       - image: python:<< parameters.python_version >>-alpine
-      - image: mysql:5.6
+      - image: mysql:5.7
         command: mysqld --character-set-server=utf8 --collation-server=utf8_general_ci
         environment:
           MYSQL_ROOT_PASSWORD: ""

--- a/Dockerfile-3.8
+++ b/Dockerfile-3.8
@@ -1,13 +1,15 @@
 # Dockerfile
 
-FROM python:3.8.5-alpine3.12
+FROM ubuntu:20.04
 
 ENV VIRTUAL_ENV=/blockstore/venv
 
-RUN apk update && apk upgrade
-RUN apk add bash bash-completion build-base git perl mariadb-dev libffi-dev
+RUN apt-get update
+RUN apt-get install libmysqlclient-dev libjpeg-dev libssl-dev libffi-dev python3 python3-venv python3-pip git -y
 
 RUN python3.8 -m venv $VIRTUAL_ENV
 
-RUN echo 'cd /blockstore/app/' >> ~/.bashrc
-RUN echo 'export PATH=$VIRTUAL_ENV/bin:$PATH' >> ~/.bashrc
+RUN echo 'cd /blockstore/app/' > ~/.bashrc.new
+RUN echo 'export PATH=$VIRTUAL_ENV/bin:$PATH' >> ~/.bashrc.new
+RUN cat ~/.bashrc >> ~/.bashrc.new
+RUN mv ~/.bashrc.new ~/.bashrc

--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,8 @@ clean: ## Remove all generated files
 	rm -f diff-cover.html
 
 requirements: ## Install requirements for development
-    # We can't add this to requirements. It changes the way pip itself works.
-    ${VENV_BIN}/pip install wheel
+	# We can't add this to requirements. It changes the way pip itself works.
+	${VENV_BIN}/pip install wheel
 	${VENV_BIN}/pip install -r requirements/local.txt --exists-action w
 
 requirements-test: ## Install requirements for testing

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ dev.up:  # Start Blockstore container
 	docker-compose --project-name "blockstore${PYTHON_VERSION}" -f "docker-compose-${PYTHON_VERSION}.yml" up -d
 
 dev.provision:  # Provision Blockstore service
-	docker exec -t edx.devstack.mysql /bin/bash -c 'mysql -uroot <<< "create database if not exists blockstore_db;"'
+	docker exec -t edx.devstack.mysql57 /bin/bash -c 'mysql -uroot <<< "create database if not exists blockstore_db;"'
 	docker exec -t ${CONTAINER_NAME} /bin/bash -c 'source ~/.bashrc && make requirements && make migrate'
 
 stop:  # Stop Blockstore container
@@ -75,13 +75,13 @@ easyserver: dev.up dev.provision  # Start and provision a Blockstore container a
 
 testserver:  # Run an isolated ephemeral instance of Blockstore for use by edx-platform tests
 	docker-compose --project-name "blockstore-testserver${PYTHON_VERSION}" -f "docker-compose-testserver-${PYTHON_VERSION}.yml" up -d
-	docker exec -t edx.devstack.mysql /bin/bash -c 'mysql -uroot <<< "create database if not exists blockstore_test_db;"'
+	docker exec -t edx.devstack.mysql57 /bin/bash -c 'mysql -uroot <<< "create database if not exists blockstore_test_db;"'
 	docker exec -t ${CONTAINER_NAME}-test /bin/bash -c 'source ~/.bashrc && make requirements && make migrate && ./manage.py shell < provision-testserver-data.py'
 	# Now run blockstore until the user hits CTRL-C:
 	docker-compose --project-name "blockstore-testserver${PYTHON_VERSION}" -f "docker-compose-testserver-${PYTHON_VERSION}.yml" exec blockstore /blockstore/venv/bin/python /blockstore/app/manage.py runserver 0.0.0.0:18251
 	# And destroy everything except the virtualenv volume (which we want to reuse to save time):
 	docker-compose --project-name "blockstore-testserver${PYTHON_VERSION}" -f "docker-compose-testserver-${PYTHON_VERSION}.yml" down
-	docker exec -t edx.devstack.mysql /bin/bash -c 'mysql -uroot <<< "drop database blockstore_test_db;"'
+	docker exec -t edx.devstack.mysql57 /bin/bash -c 'mysql -uroot <<< "drop database blockstore_test_db;"'
 
 html_coverage: ## Generate HTML coverage report
 	${VENV_BIN}/coverage html

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ dev.provision:  # Provision Blockstore service
 	docker exec -t ${CONTAINER_NAME} /bin/bash -c 'source ~/.bashrc && make requirements && make migrate'
 
 stop:  # Stop Blockstore container
-	docker-compose --project-name blockstore -f docker-compose.yml stop
+	docker-compose --project-name blockstore${PYTHON_VERSION} -f docker-compose-${PYTHON_VERSION}.yml stop
 
 pull:  # Update docker images that this depends on.
 	docker pull python:3.8.5-alpine3.12

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,8 @@ clean: ## Remove all generated files
 	rm -f diff-cover.html
 
 requirements: ## Install requirements for development
+    # We can't add this to requirements. It changes the way pip itself works.
+    ${VENV_BIN}/pip install wheel
 	${VENV_BIN}/pip install -r requirements/local.txt --exists-action w
 
 requirements-test: ## Install requirements for testing

--- a/blockstore/settings/base.py
+++ b/blockstore/settings/base.py
@@ -96,6 +96,7 @@ DATABASES = {
             # the correct unicode implementation.
             # Note that this limits the length of InnoDB indexed columns to 191 characters.
             'charset': 'utf8mb4',
+            'init_command': 'SET NAMES utf8mb4',
         },
     }
 }

--- a/blockstore/settings/local.py
+++ b/blockstore/settings/local.py
@@ -26,7 +26,7 @@ DATABASES = {
         'NAME': os.environ.get('MYSQL_DATABASE', 'blockstore_db'),
         'USER': os.environ.get('MYSQL_USER', 'root'),
         'PASSWORD': os.environ.get('MYSQL_ROOT_PASSWORD', ''),
-        'HOST': os.environ.get('MYSQL_HOST', 'mysql'),
+        'HOST': os.environ.get('MYSQL_HOST', 'mysql57'),
         'PORT': int(os.environ.get('MYSQL_PORT', '3306')),
         'OPTIONS': {
             # Use a non-broken unicode encoding. See "mysql_unicode/migrations/0001_initial.py"
@@ -34,6 +34,7 @@ DATABASES = {
             # the correct unicode implementation.
             # Note that this limits the length of InnoDB indexed columns to 191 characters.
             'charset': 'utf8mb4',
+            'init_command': 'SET NAMES utf8mb4',
         },
     }
 }

--- a/blockstore/settings/test.py
+++ b/blockstore/settings/test.py
@@ -13,7 +13,7 @@ DATABASES = {
         'NAME': os.environ.get('MYSQL_DATABASE', 'blockstore_db'),
         'USER': os.environ.get('MYSQL_USER', 'root'),
         'PASSWORD': os.environ.get('MYSQL_ROOT_PASSWORD', ''),
-        'HOST': os.environ.get('MYSQL_HOST', 'mysql'),
+        'HOST': os.environ.get('MYSQL_HOST', 'mysql57'),
         'PORT': int(os.environ.get('MYSQL_PORT', '3306')),
         'OPTIONS': {
             # Use a non-broken unicode encoding. See "mysql_unicode/migrations/0001_initial.py"
@@ -21,6 +21,7 @@ DATABASES = {
             # the correct unicode implementation.
             # Note that this limits the length of InnoDB indexed columns to 191 characters.
             'charset': 'utf8mb4',
+            'init_command': 'SET NAMES utf8mb4',
         },
     },
 }

--- a/docker-compose-3.8.yml
+++ b/docker-compose-3.8.yml
@@ -23,7 +23,7 @@ services:
     environment:
       - MYSQL_DATABASE=blockstore_db
       - MYSQL_USER=root
-      - MYSQL_HOST=mysql
+      - MYSQL_HOST=mysql57
       - MYSQL_PORT=3306
 
 networks:

--- a/docker-compose-testserver-3.8.yml
+++ b/docker-compose-testserver-3.8.yml
@@ -26,7 +26,7 @@ services:
     environment:
       - MYSQL_DATABASE=blockstore_test_db
       - MYSQL_USER=root
-      - MYSQL_HOST=mysql
+      - MYSQL_HOST=mysql57
       - MYSQL_PORT=3306
 
 networks:


### PR DESCRIPTION
## Description

This upgrades the blockstore to use the MySQL 5.7 container as its backend, and also updates CircleCI to use it in testing. It also changes the Dockerfile to use Ubuntu 20.04 instead of Alpine to better match other devstack images and prove compatibility.

## Jira Ticket

https://openedx.atlassian.net/browse/TNL-7642

## Author Comments, Concerns, and Open Questions

The directions in https://openedx.atlassian.net/wiki/spaces/AC/pages/1135181906/Upgrade+base+OS+from+Ubuntu+16.04+to+20.04 involve access to a lot of sandbox tools that I do not have access to. It would be best if the requirements not covered by this PR were handled by an edX team member.

## Test Instructions

Stop any running copies of blockstore. Remove all blockstore cache volumes:

```
docker volume rm blockstore38_blockstore_venv_3_8_5
docker volume rm blockstore-testserver38_blockstore_venv_3_8_5
```

**Note** The above command is likely to fail and tell you which containers hold those volumes. Use `docker kill container` and `docker rm container` where 'container' is the container hash to remove these containers manually.

Now, rebuild the blockstore image:

```
docker-compose -f docker-compose-3.8.yml build --no-cache
```

Now, launch blockstore:

```
make easyserver
```

Then, run the unit tests. After you've finished with the unit tests, close out of easyserver, run testserver, and run integration tests.

You may also test to make sure that things still work on MySQL 5.6 by doing a find-and-replace in the repository for 'mysql57' to 'mysql'. Then run run the servers/tests once more.

## Reviewers:

- [ ] @symbolist and/or @bradenmacdonald 
- [ ] @kdmccormick 