### PR TITLE
Upgrade Django to 2.2.17

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,7 +17,7 @@ django-environ==0.4.5     # via -c requirements/constraints.txt, -r requirements
 django-filter==2.1.0      # via -c requirements/constraints.txt, -r requirements/base.in
 django-rest-swagger==2.2.0  # via -r requirements/base.in
 django-waffle==2.0.0      # via -r requirements/base.in
-django==2.2.16            # via -c requirements/constraints.txt, -r requirements/base.in, django-filter, djangorestframework, drf-nested-routers, edx-auth-backends, edx-django-release-util
+django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.in, django-filter, djangorestframework, drf-nested-routers, edx-auth-backends, edx-django-release-util
 djangorestframework-expander==0.2.3  # via -r requirements/base.in
 djangorestframework==3.12.1  # via -r requirements/base.in, django-rest-swagger, djangorestframework-expander, drf-nested-routers
 git+https://github.com/alanjds/drf-nested-routers.git@8686392f91b114e01f3781807dea60e9a80d3e07#egg=drf-nested-routers==0.91  # via -r requirements/github.in

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -27,7 +27,7 @@ django-environ==0.4.5     # via -c requirements/constraints.txt, -r requirements
 django-filter==2.1.0      # via -c requirements/constraints.txt, -r requirements/test.txt
 django-rest-swagger==2.2.0  # via -r requirements/test.txt
 django-waffle==2.0.0      # via -r requirements/test.txt
-django==2.2.16            # via -c requirements/constraints.txt, -r requirements/test.txt, django-debug-toolbar, django-filter, djangorestframework, drf-nested-routers, edx-auth-backends, edx-django-release-util
+django==2.2.17            # via -c requirements/constraints.txt, -r requirements/test.txt, django-debug-toolbar, django-filter, djangorestframework, drf-nested-routers, edx-auth-backends, edx-django-release-util
 djangorestframework-expander==0.2.3  # via -r requirements/test.txt
 djangorestframework==3.12.1  # via -r requirements/test.txt, django-rest-swagger, djangorestframework-expander, drf-nested-routers
 docutils==0.16            # via -r requirements/docs.txt, sphinx

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -20,7 +20,7 @@ django-filter==2.1.0      # via -c requirements/constraints.txt, -r requirements
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-storages==1.10.1   # via -r requirements/production.in
 django-waffle==2.0.0      # via -r requirements/base.txt
-django==2.2.16            # via -c requirements/constraints.txt, -r requirements/base.txt, django-filter, django-storages, djangorestframework, drf-nested-routers, edx-auth-backends, edx-django-release-util
+django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.txt, django-filter, django-storages, djangorestframework, drf-nested-routers, edx-auth-backends, edx-django-release-util
 djangorestframework-expander==0.2.3  # via -r requirements/base.txt
 djangorestframework==3.12.1  # via -r requirements/base.txt, django-rest-swagger, djangorestframework-expander, drf-nested-routers
 git+https://github.com/alanjds/drf-nested-routers.git@8686392f91b114e01f3781807dea60e9a80d3e07#egg=drf-nested-routers==0.91  # via -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -24,7 +24,7 @@ django-environ==0.4.5     # via -c requirements/constraints.txt, -r requirements
 django-filter==2.1.0      # via -c requirements/constraints.txt, -r requirements/base.txt
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-waffle==2.0.0      # via -r requirements/base.txt
-django==2.2.16            # via -c requirements/constraints.txt, -r requirements/base.txt, django-filter, djangorestframework, drf-nested-routers, edx-auth-backends, edx-django-release-util
+django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.txt, django-filter, djangorestframework, drf-nested-routers, edx-auth-backends, edx-django-release-util
 djangorestframework-expander==0.2.3  # via -r requirements/base.txt
 djangorestframework==3.12.1  # via -r requirements/base.txt, django-rest-swagger, djangorestframework-expander, drf-nested-routers
 git+https://github.com/alanjds/drf-nested-routers.git@8686392f91b114e01f3781807dea60e9a80d3e07#egg=drf-nested-routers==0.91  # via -r requirements/base.txt


### PR DESCRIPTION
## Description

This is to make sure that we use the same Django version for all applications.

This PR should be merged in time for the Koa release (cc @nedbat); it is ready for review.