### PR TITLE
SE-3692 Update make pull so it pulls the correct image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ stop:  # Stop Blockstore container
 	docker-compose ${BLOCKSTORE_DOCKER_COMPOSE_OPTS} stop
 
 pull:  # Update docker images that this depends on.
-	docker pull python:3.8.5-alpine3.12
+	docker pull ubuntu:20.04
 
 destroy:  # Remove Blockstore container, network and volumes. Destructive.
 	docker-compose ${BLOCKSTORE_DOCKER_COMPOSE_OPTS} down -v


### PR DESCRIPTION
ubuntu:20.04 is now used in the Dockerfile

**JIRA tickets**: [OSPR-5283](https://openedx.atlassian.net/browse/OSPR-5283)

**Dependencies**: None

**Merge deadline**: None

**Testing instructions**:

1. run `make pull`
2. verify that it pulls the same image used as the base for the docker image


**Reviewers**
- [ ] @gabor-boros
- [ ] edX reviewer[s] TBD

