### PR TITLE
feat: allow config of storage backend for longer-lived urls

### DIFF
--- a/blockstore/apps/bundles/storage.py
+++ b/blockstore/apps/bundles/storage.py
@@ -1,0 +1,170 @@
+"""
+Django Storage backends for bundles app.
+
+If you don't care about the specifics, just import and use `default_asset_storage`,
+which is a `Storage` instance just like `default_storage`.
+"""
+from django.conf import settings
+from django.core.files.storage import Storage, default_storage, get_storage_class
+
+
+# You probably just want to import this.
+# (Forward-declaring here for visibility)
+default_asset_storage: Storage
+
+
+class LongLivedSignedUrlStorage(Storage):  # pylint: disable=abstract-method
+    """
+    Storage backend for generating longer-lived signed URLs.
+
+    It only implements the `url` operation; all other operations (delete,
+    exists, listdir, etc.) will raise NotImplementedErrors.
+    This is why we disable pylint's abstract method check for this class.
+
+    THIS CLASS IS SPECIFIC TO THE S3Boto3Storage BACKEND.
+    It will not work with FileSystemStorage or any other backend.
+    (If it seemed prudent, though, this class could be generalized to work
+     with other storage backends.)
+
+    Context:
+
+        When powering Blockstore with the S3SBoto3torageBackend, asset URLs are
+        exposed to clients (and users) by generating signed S3 URLs.
+        The ideal time-to-live of these URLs is ~24-48 hours;
+        that is, long enough such that users may interact with content without
+        losing access to assets in the middle of their session,
+        but short enough as to avoid granting perpetual unauthenticated access
+        to copyrighted content.
+
+        However, servers deployed on AWS are often given *temporary*
+        credentials instead of permanent ones. In particular, edx.org
+        does this according to the AWS IAM best practices [1], which state:
+        > "Use temporary security credentials (IAM roles) instead of long-term access keys".
+
+        If such temporary credentials are used
+        to sign S3 URLs, then the S3 URLs will automatically expire when
+        then the temporary credentials  expire (even if the URL was just
+        signed!). Thus, temporary credentials, although preferred by some operators,
+        cannot be depended upon to sign our "long-lasting" S3 URLs.
+
+        The compromise here is to allow Blockstore to have two separate
+        sets of credentials:
+        1. temporary credentials that allow full read/write/delete access to S3
+           (along with any other necessary AWS permissions), and
+        2. permanent credentials that *only* grant read access to S3.
+
+        The first set of credentials remain the default credentials for Blockstore,
+        while the second set of credentials can be specifically used to sign
+        S3 URLs. Hence, this class.
+
+        [1] https://docs.aws.amazon.com/general/latest/gr/aws-access-keys-best-practices.html
+    """
+
+    class BackendNotAvailable(Exception):
+        """
+        Raised if `LongLivedSignedUrlStorage` is not configured for use.
+        """
+        def __str__(self):
+            return (
+                f"In order to instantiate this storage backend, "
+                "boto3 must be installed "
+                "and both BUNDLE_ASSET_URL_STORAGE_KEY "
+                "and BUNDLE_ASSET_URL_STORAGE_SECRET "
+                "must be configured in Django settings."
+            )
+
+    def __init__(self):
+        """
+        Construct a storage backend instance.
+
+        Raises `BackendNotAvailable` if we are not configured.
+        """
+        try:
+            S3Boto3Storage = get_storage_class("storages.backends.s3boto3.S3Boto3Storage")
+        except ImportError as import_error:
+            raise self.BackendNotAvailable from import_error
+        try:
+            key = settings.BUNDLE_ASSET_URL_STORAGE_KEY
+            secret = settings.BUNDLE_ASSET_URL_STORAGE_SECRET
+        except AttributeError as attr_error:
+            raise self.BackendNotAvailable from attr_error
+        if not (key and secret):
+            raise self.BackendNotAvailable
+        self.s3_backend = S3Boto3Storage(
+            # All other S3 settings will be pulled in automatically from Django settings
+            # (such as AWS_QUERYSTRING_EXPIRE and AWS_STORAGE_BUCKET_NAME).
+            access_key=key, secret_key=secret
+        )
+
+    def url(self, name):
+        """
+        Generate a URL using the configured backend.
+        """
+        return self.s3_backend.url(name)
+
+
+class AssetStorage(Storage):
+    """
+    Storage backend for assets related to bundles.
+
+    This is largely a pass-through wrapper around the `default_storage` class;
+    the one key difference is that URLs are generated through the
+    `LongLivedSignedUrlStorage` class, if it is active.
+    """
+
+    def __init__(self):
+        """
+        Initialize an instance of AssetStorage.
+
+        If `LongLivedSignedUrlStorage` is active, then instantiate an instance of
+        it for generating URLs; otherwise, fall back to the default storage class.
+        """
+        try:
+            self.url_backend = LongLivedSignedUrlStorage()
+        except LongLivedSignedUrlStorage.BackendNotAvailable:
+            self.url_backend = default_storage
+
+    def url(self, name):
+        return self.url_backend.url(name)
+
+    def delete(self, name):
+        return default_storage.delete(name)
+
+    def exists(self, name):
+        return default_storage.exists(name)
+
+    def listdir(self, path):
+        return default_storage.listdir(path)
+
+    def path(self, name):
+        return default_storage.path(name)
+
+    def size(self, name):
+        return default_storage.size(name)
+
+    def get_accessed_time(self, name):
+        return default_storage.get_accessed_time(name)
+
+    def get_created_time(self, name):
+        return default_storage.get_created_time(name)
+
+    def get_modified_time(self, name):
+        return default_storage.get_modified_time(name)
+
+    def get_valid_name(self, name):
+        return default_storage.get_valid_name(name)
+
+    def get_alternative_name(self, name):
+        return default_storage.get_alternative_name(name)
+
+    def get_available_name(self, name, max_length=None):
+        return default_storage.get_available_name(name, max_length=None)
+
+    def _open(self, name, mode='rb'):
+        return default_storage._open(name, mode=mode)  # pylint: disable=protected-access
+
+    def _save(self, name, content):
+        return default_storage._save(name, content)  # pylint: disable=protected-access
+
+
+default_asset_storage = AssetStorage()

--- a/blockstore/apps/bundles/store.py
+++ b/blockstore/apps/bundles/store.py
@@ -18,13 +18,13 @@ import logging
 import json
 import pytz
 
-from django.core.files.storage import default_storage
 from django.core.files.base import ContentFile, File
 from django.dispatch import Signal
 import attr
 from pyblake2 import blake2b
 
 from .links import Dependency, Link, LinkCollection, LinkChangeSet
+from .storage import default_asset_storage
 
 logger = logging.getLogger(__name__)
 snapshot_created = Signal(providing_args=["bundle_uuid", "hash_digest"])
@@ -246,7 +246,7 @@ class SnapshotRepo:
       by different paths in different versions.
     """
     def __init__(self, storage=None):
-        self.storage = storage or default_storage
+        self.storage = storage or default_asset_storage
 
     def get(self, bundle_uuid: UUID, snapshot_digest: bytes) -> Snapshot:
         """
@@ -367,7 +367,7 @@ class DraftRepo:
         to where we can get Snapshot data.
         """
         self.snapshot_repo = snapshot_repo
-        self.storage = storage or default_storage
+        self.storage = storage or default_asset_storage
 
     @classmethod
     def _data_file_path(cls, draft_uuid, file_path):

--- a/blockstore/apps/bundles/tests/test_storage.py
+++ b/blockstore/apps/bundles/tests/test_storage.py
@@ -1,0 +1,89 @@
+"""
+Tests for storage classes in storage.py
+"""
+from unittest.mock import patch
+
+from django.test import override_settings
+import pytest
+
+from .. import storage as storage_module
+
+
+class _MockS3backend:
+    """
+    A fake replacment for S3Boto3Backend in these tests.
+    """
+    def __init__(self, **settings):
+        self.accesss_key = settings["access_key"]
+        self.secret_key = settings["secret_key"]
+
+    def url(self, name):
+        return f"https://example.com/s3/{name}"
+
+
+_patch_default_storage = patch.object(
+    storage_module, 'default_storage', autospec=True
+)
+_patch_get_storage_class = patch.object(
+    storage_module, 'get_storage_class', autospec=True, return_value=_MockS3backend
+)
+_patch_s3_credentials = override_settings(
+    BUNDLE_ASSET_URL_STORAGE_KEY="a-key", BUNDLE_ASSET_URL_STORAGE_SECRET="a-secret"
+)
+
+
+@_patch_default_storage
+def test_asset_storage_long_lived_urls_disabled(mock_default_storage):
+    """
+    Test that `AssetStorage` is just pass-through when long-lived S3
+    URL signing is not configured.
+    """
+    backend = storage_module.AssetStorage()
+    assert backend.url_backend is mock_default_storage
+    backend.url('abc')
+    backend.listdir('123')
+    backend.get_accessed_time('xyz')
+    mock_default_storage.url.assert_called_once_with('abc')
+    mock_default_storage.listdir.assert_called_once_with('123')
+    mock_default_storage.get_accessed_time.assert_called_once_with('xyz')
+
+
+@_patch_s3_credentials
+@_patch_get_storage_class
+@_patch_default_storage
+def test_asset_storage_long_lived_urls_enabled(mock_default_storage, *_args):
+    """
+    Test that `AssetStorage` is just pass-through when long-lived S3
+    URL signing is not configured.
+    """
+    backend = storage_module.AssetStorage()
+    assert isinstance(backend.url_backend, storage_module.LongLivedSignedUrlStorage)
+    assert backend.url_backend.s3_backend.accesss_key == "a-key"
+    assert backend.url_backend.s3_backend.secret_key == "a-secret"
+    assert backend.url('abc') == "https://example.com/s3/abc"
+    backend.listdir('123')
+    backend.get_accessed_time('xyz')
+    assert not mock_default_storage.url.called
+    mock_default_storage.listdir.assert_called_once_with('123')
+    mock_default_storage.get_accessed_time.assert_called_once_with('xyz')
+
+
+@_patch_default_storage
+def test_long_lived_url_storage_raises_if_no_boto3(*_args):
+    """
+    Test that `AssetStorage` is just pass-through when long-lived S3
+    URL signing is not configured.
+    """
+    with pytest.raises(storage_module.LongLivedSignedUrlStorage.BackendNotAvailable):
+        storage_module.LongLivedSignedUrlStorage()
+
+
+@_patch_get_storage_class
+@_patch_default_storage
+def test_long_lived_url_storage_raises_if_no_credentials(*_args):
+    """
+    Test that `AssetStorage` is just pass-through when long-lived S3
+    URL signing is not configured.
+    """
+    with pytest.raises(storage_module.LongLivedSignedUrlStorage.BackendNotAvailable):
+        storage_module.LongLivedSignedUrlStorage()

--- a/blockstore/settings/base.py
+++ b/blockstore/settings/base.py
@@ -309,3 +309,21 @@ LOGGING = {
         },
     }
 }
+
+# .. setting_name: BUNDLE_ASSET_URL_STORAGE_KEY
+# .. setting_default: None
+# .. setting_description: When this is set, `BUNDLE_ASSET_URL_STORAGE_SECRET` is
+#  set, and `boto3` is installed, this is used as an AWS IAM access key for
+#  generating signed, read-only URLs for assets stored in S3.
+#  Otherwise, URLs are generated based on the default storage configuration.
+#  See `blockstore.apps.bundles.storage.LongLivedSignedUrlStorage` for details.
+BUNDLE_ASSET_URL_STORAGE_KEY = None
+
+# .. setting_name: BUNDLE_ASSET_URL_STORAGE_SECRET
+# .. setting_default: None
+# .. setting_description: When this is set, `BUNDLE_ASSET_URL_STORAGE_KEY` is
+#  set, and `boto3` is installed, this is used as an AWS IAM secret key for
+#  generating signed, read-only URLs for assets stored in S3.
+#  Otherwise, URLs are generated based on the default storage configuration.
+#  See `blockstore.apps.bundles.storage.LongLivedSignedUrlStorage` for details.
+BUNDLE_ASSET_URL_STORAGE_SECRET = None


### PR DESCRIPTION
## Description

This will help fix a long-running bug; specifically:
* Blockstore generates signed URLs in order to grant
  temporary access to snapshot/draft asset files when
  using S3 as a backend (as it does on edx.org).
* These signed URLs are meant to be valid for ~24-48
  hours, allowing clients and users to visit or cache
  the links for a reasonable amount of time,
  but still having them expire eventually in order
  to prevent free access to copyrighted content.
* However, blockstore.edx.org is configured with
  a temporary IAM credential, which can expire at
  any time, and lasts only an hour at max. So, URLs
  signed with these temporary credentials are
  at risk of expiring at any time.

As a fix, This commit introduces two new Django settings:
* BUNDLE_ASSET_URL_STORAGE_KEY
* BUNDLE_ASSET_URL_STORAGE_SECRET
If these are set AND if S3Boto3 storage is available, then
Blockstore will use them to sign S3 URLs in place
of the default credentials.

This way, operators may configure Blockstore generally
with temporary IAM credentials, but also provide a
second set of *permanent* credentials that are only
granted the GetObject permission on a particular bucket,
thus allowing Blockstore to sign URLs lasting as long
as AWS_QUERYSTRING_EXPIRE is configured for.

## Author Comments, Concerns, and Open Questions

The specific names of the URL-signing credential settings are subject to change based on what @fredsmith chooses.

edX Jira ticket: https://openedx.atlassian.net/browse/TNL-7771

## Test Instructions

I included some mock-heavy unit tests to make sure there are no dumb mistakes in `blockstore/apps/bundles/storage.py`, but the actual interaction with S3 seems like it would be hard to test locally. So, we can test that this actually works on Stage before shipping it.
