### PR TITLE
BOM-2247: Upgrade pip-tools to v5.5

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -26,3 +26,5 @@ django-filter==2.1.0
 factory-boy<3.0.0
 
 mysqlclient==1.3.14
+
+pip-tools<6.0

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,8 +5,7 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==5.3.1          # via -r requirements/pip-tools.in
-six==1.15.0               # via pip-tools
+pip-tools==5.5.0          # via -c requirements/constraints.txt, -r requirements/pip-tools.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip


### PR DESCRIPTION
Currently, we are have pinned pip to version 20.1.1 in configuration, which is compatible with pip-tools < 6.0 So in this PR we are upgrading pip-tools to 5.5* according to this compatibility chart
https://github.com/jazzband/pip-tools/#versions-and-compatibility

Relevant JIRA: https://openedx.atlassian.net/browse/BOM-2247