### PR TITLE
Fix and re-run requirements upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ html_coverage: ## Generate HTML coverage report
 
 quality: ## Run quality checks
 	${VENV_BIN}/pycodestyle --config=pycodestyle blockstore tagstore *.py
-	${VENV_BIN}/pylint --rcfile=pylintrc blockstore tagstore *.py
+	${VENV_BIN}/pylint --django-settings-module=blockstore.settings.test --rcfile=pylintrc blockstore tagstore *.py
 	${VENV_BIN}/mypy --config-file tagstore/mypy.ini tagstore
 
 validate: test quality ## Run tests and quality checks

--- a/blockstore/apps/api/v1/serializers/drafts.py
+++ b/blockstore/apps/api/v1/serializers/drafts.py
@@ -153,7 +153,7 @@ class DraftFileUpdateSerializer(serializers.BaseSerializer):
             except binascii.Error as err:
                 raise ValidationError(
                     f"Error decoding file {file_path}: {err} (check if it's base64 encoded?)"
-                )
+                ) from err
             return ContentFile(binary_file_data)
 
         # TODO: make sure they can't write outside the draft space
@@ -211,10 +211,10 @@ class DraftFileUpdateSerializer(serializers.BaseSerializer):
             try:
                 bundle_uuid_str = bv_info['bundle_uuid']
                 bundle_uuid = uuid.UUID(bundle_uuid_str)
-            except ValueError:
+            except ValueError as err:
                 raise ValidationError(
                     f"Link {name}: {bundle_uuid_str} is not a valid UUID."
-                )
+                ) from err
 
             # At this point it's syntactically correct, but it might be pointing
             # to a BundleVersion that doesn't really exist.

--- a/blockstore/apps/api/v1/tests/helpers.py
+++ b/blockstore/apps/api/v1/tests/helpers.py
@@ -62,8 +62,8 @@ def response_data(response):
     """
     try:
         data = json.loads(response.content.decode('utf-8'))
-    except Exception:
+    except Exception as exc:
         raise ValueError(
             f"The following could not be parsed as JSON: {response.content}"
-        )
+        ) from exc
     return data

--- a/blockstore/apps/api/v1/views/drafts.py
+++ b/blockstore/apps/api/v1/views/drafts.py
@@ -93,7 +93,7 @@ class DraftViewSet(viewsets.ModelViewSet):
         # Generic model serializer is sufficience for other views.
         return DraftSerializer
 
-    def partial_update(self, request, uuid):
+    def partial_update(self, request, uuid):  # pylint: disable=arguments-differ
         """
         Create, update, and delete files in a Draft.
 
@@ -129,8 +129,10 @@ class DraftViewSet(viewsets.ModelViewSet):
         draft_repo = DraftRepo(SnapshotRepo())
         try:
             draft_repo.update(uuid, files_to_write, dependencies_to_write)
-        except LinkCycleError:
-            raise serializers.ValidationError("Link cycle detected: Cannot create draft.")
+        except LinkCycleError as err:
+            raise serializers.ValidationError(
+                "Link cycle detected: Cannot create draft."
+            ) from err
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -179,10 +181,10 @@ class DraftViewSet(viewsets.ModelViewSet):
         }
         return Response(result, status=status.HTTP_201_CREATED)
 
-    def destroy(self, request, uuid):
+    def destroy(self, request, uuid):  # pylint: disable=arguments-differ
         """
         This removes any files that were staged along with the database entry.
         """
         draft_repo = DraftRepo(SnapshotRepo())
         draft_repo.delete(uuid)
-        return super().destroy(request, uuid)  # pylint: disable=no-member
+        return super().destroy(request, uuid)

--- a/blockstore/apps/bundles/models.py
+++ b/blockstore/apps/bundles/models.py
@@ -199,7 +199,6 @@ class Draft(models.Model):
     )
     name = models.CharField(max_length=MAX_CHAR_FIELD_LENGTH)
 
-    # pylint: disable=arguments-differ
     def save(self, *args, **kwargs):
         if not self.pk:
             draft_repo = DraftRepo(SnapshotRepo())

--- a/blockstore/apps/bundles/storage.py
+++ b/blockstore/apps/bundles/storage.py
@@ -66,7 +66,7 @@ class LongLivedSignedUrlStorage(Storage):  # pylint: disable=abstract-method
         """
         def __str__(self):
             return (
-                f"In order to instantiate this storage backend, "
+                "In order to instantiate this storage backend, "
                 "boto3 must be installed "
                 "and both BUNDLE_ASSET_URL_STORAGE_KEY "
                 "and BUNDLE_ASSET_URL_STORAGE_SECRET "

--- a/blockstore/apps/bundles/store.py
+++ b/blockstore/apps/bundles/store.py
@@ -259,7 +259,7 @@ class SnapshotRepo:
             with self.storage.open(storage_path, mode='rb') as snapshot_file:
                 snapshot_raw_data = snapshot_file.read()
                 snapshot_json = json.loads(snapshot_raw_data.decode('utf-8'))
-        except FileNotFoundError:
+        except FileNotFoundError as err:
             logger.error(
                 "Snapshot %s,%s not found at: %s",
                 bundle_uuid,
@@ -268,7 +268,7 @@ class SnapshotRepo:
             )
             raise Snapshot.NotFoundError(
                 f"Snapshot {snapshot_digest.hex()} for Bundle {bundle_uuid} not found"
-            )
+            ) from err
 
         return Snapshot(
             bundle_uuid=bundle_uuid,
@@ -675,7 +675,7 @@ class DraftRepo:
 
 class BundleDataJSONEncoder(json.JSONEncoder):
     """Default JSON serialization."""
-    def default(self, o):  # pylint: disable=method-hidden
+    def default(self, o):
         if isinstance(o, FileInfo):
             return [o.public, o.size, o.hash_digest.hex()]
         elif isinstance(o, UUID):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,48 +4,93 @@
 #
 #    make upgrade
 #
-attrs==18.2.0             # via -c requirements/constraints.txt, -r requirements/base.in
-certifi==2020.11.8        # via requests
-cffi==1.14.3              # via cryptography
-chardet==3.0.4            # via requests
-coreapi==2.3.3            # via drf-yasg
-coreschema==0.0.4         # via coreapi, drf-yasg
-cryptography==3.2.1       # via social-auth-core
-defusedxml==0.6.0         # via python3-openid, social-auth-core
-django-cors-headers==2.2.1  # via -c requirements/constraints.txt, -r requirements/base.in
-django-environ==0.4.5     # via -c requirements/constraints.txt, -r requirements/base.in
-django-filter==2.1.0      # via -c requirements/constraints.txt, -r requirements/base.in
-django-waffle==2.0.0      # via -r requirements/base.in
-django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.in, django-filter, djangorestframework, drf-nested-routers, drf-yasg, edx-api-doc-tools, edx-auth-backends, edx-django-release-util
-djangorestframework-expander==0.2.3  # via -r requirements/base.in
-djangorestframework==3.12.2  # via -r requirements/base.in, djangorestframework-expander, drf-nested-routers, drf-yasg, edx-api-doc-tools
-git+https://github.com/alanjds/drf-nested-routers.git@8686392f91b114e01f3781807dea60e9a80d3e07#egg=drf-nested-routers==0.91  # via -r requirements/github.in
-drf-yasg==1.20.0          # via edx-api-doc-tools
-edx-api-doc-tools==1.4.0  # via -r requirements/base.in
-edx-auth-backends==3.1.0  # via -r requirements/base.in
-edx-django-release-util==0.4.4  # via -r requirements/base.in
-idna==2.10                # via requests
-inflection==0.5.1         # via drf-yasg
-itypes==1.2.0             # via coreapi
-jinja2==2.11.2            # via coreschema
-markupsafe==1.1.1         # via jinja2
-mysqlclient==1.3.14       # via -c requirements/constraints.txt, -r requirements/base.in
-oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
-packaging==20.4           # via drf-yasg
-pyblake2==1.1.2           # via -r requirements/base.in
-pycparser==2.20           # via cffi
-pyjwt==1.7.1              # via edx-auth-backends, social-auth-core
-pyparsing==2.4.7          # via packaging
-python3-openid==3.2.0     # via social-auth-core
-pytz==2020.4              # via -r requirements/base.in, django
-pyyaml==5.3.1             # via edx-django-release-util
-requests-oauthlib==1.3.0  # via social-auth-core
-requests==2.24.0          # via coreapi, requests-oauthlib, social-auth-core
-ruamel.yaml.clib==0.2.2   # via ruamel.yaml
-ruamel.yaml==0.16.12      # via drf-yasg
-six==1.15.0               # via cryptography, edx-auth-backends, edx-django-release-util, packaging, social-auth-app-django, social-auth-core
-social-auth-app-django==4.0.0  # via edx-auth-backends
-social-auth-core==3.3.3   # via edx-auth-backends, social-auth-app-django
-sqlparse==0.4.1           # via -r requirements/base.in, django
-uritemplate==3.0.1        # via coreapi, drf-yasg
-urllib3==1.25.11          # via requests
+attrs==18.2.0
+    # via -c requirements/constraints.txt, -r requirements/base.in
+certifi==2020.11.8
+    # via requests
+cffi==1.14.3
+    # via cryptography
+chardet==3.0.4
+    # via requests
+coreapi==2.3.3
+    # via drf-yasg
+coreschema==0.0.4
+    # via coreapi, drf-yasg
+cryptography==3.2.1
+    # via social-auth-core
+defusedxml==0.6.0
+    # via python3-openid, social-auth-core
+django-cors-headers==2.2.1
+    # via -c requirements/constraints.txt, -r requirements/base.in
+django-environ==0.4.5
+    # via -c requirements/constraints.txt, -r requirements/base.in
+django-filter==2.1.0
+    # via -c requirements/constraints.txt, -r requirements/base.in
+django-waffle==2.0.0
+    # via -r requirements/base.in
+django==2.2.17
+    # via -c requirements/constraints.txt, -r requirements/base.in, django-filter, djangorestframework, drf-nested-routers, drf-yasg, edx-api-doc-tools, edx-auth-backends, edx-django-release-util
+djangorestframework-expander==0.2.3
+    # via -r requirements/base.in
+djangorestframework==3.12.2
+    # via -r requirements/base.in, djangorestframework-expander, drf-nested-routers, drf-yasg, edx-api-doc-tools
+git+https://github.com/alanjds/drf-nested-routers.git@8686392f91b114e01f3781807dea60e9a80d3e07#egg=drf-nested-routers==0.91
+    # via -r requirements/github.in
+drf-yasg==1.20.0
+    # via edx-api-doc-tools
+edx-api-doc-tools==1.4.0
+    # via -r requirements/base.in
+edx-auth-backends==3.1.0
+    # via -r requirements/base.in
+edx-django-release-util==0.4.4
+    # via -r requirements/base.in
+idna==2.10
+    # via requests
+inflection==0.5.1
+    # via drf-yasg
+itypes==1.2.0
+    # via coreapi
+jinja2==2.11.2
+    # via coreschema
+markupsafe==1.1.1
+    # via jinja2
+mysqlclient==1.3.14
+    # via -c requirements/constraints.txt, -r requirements/base.in
+oauthlib==3.1.0
+    # via requests-oauthlib, social-auth-core
+packaging==20.4
+    # via drf-yasg
+pyblake2==1.1.2
+    # via -r requirements/base.in
+pycparser==2.20
+    # via cffi
+pyjwt==1.7.1
+    # via edx-auth-backends, social-auth-core
+pyparsing==2.4.7
+    # via packaging
+python3-openid==3.2.0
+    # via social-auth-core
+pytz==2020.4
+    # via -r requirements/base.in, django
+pyyaml==5.3.1
+    # via edx-django-release-util
+requests-oauthlib==1.3.0
+    # via social-auth-core
+requests==2.24.0
+    # via coreapi, requests-oauthlib, social-auth-core
+ruamel.yaml.clib==0.2.2
+    # via ruamel.yaml
+ruamel.yaml==0.16.12
+    # via drf-yasg
+six==1.15.0
+    # via cryptography, edx-auth-backends, edx-django-release-util, packaging, social-auth-app-django, social-auth-core
+social-auth-app-django==4.0.0
+    # via edx-auth-backends
+social-auth-core==3.3.3
+    # via edx-auth-backends, social-auth-app-django
+sqlparse==0.4.1
+    # via -r requirements/base.in, django
+uritemplate==3.0.1
+    # via coreapi, drf-yasg
+urllib3==1.25.11
+    # via requests

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,45 +4,71 @@
 #
 #    make upgrade
 #
-attrs==18.2.0
-    # via -c requirements/constraints.txt, -r requirements/base.in
-certifi==2020.11.8
+attrs==21.2.0
+    # via -r requirements/base.in
+certifi==2020.12.5
     # via requests
-cffi==1.14.3
+cffi==1.14.5
     # via cryptography
-chardet==3.0.4
+chardet==4.0.0
     # via requests
 coreapi==2.3.3
     # via drf-yasg
 coreschema==0.0.4
-    # via coreapi, drf-yasg
-cryptography==3.2.1
-    # via social-auth-core
-defusedxml==0.6.0
-    # via python3-openid, social-auth-core
+    # via
+    #   coreapi
+    #   drf-yasg
+cryptography==3.3.2
+    # via
+    #   -c requirements/constraints.txt
+    #   social-auth-core
+defusedxml==0.7.1
+    # via
+    #   python3-openid
+    #   social-auth-core
 django-cors-headers==2.2.1
-    # via -c requirements/constraints.txt, -r requirements/base.in
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
 django-environ==0.4.5
-    # via -c requirements/constraints.txt, -r requirements/base.in
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
 django-filter==2.1.0
-    # via -c requirements/constraints.txt, -r requirements/base.in
-django-waffle==2.0.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
+django-waffle==2.2.0
     # via -r requirements/base.in
-django==2.2.17
-    # via -c requirements/constraints.txt, -r requirements/base.in, django-filter, djangorestframework, drf-nested-routers, drf-yasg, edx-api-doc-tools, edx-auth-backends, edx-django-release-util
+django==2.2.23
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
+    #   django-filter
+    #   djangorestframework
+    #   drf-nested-routers
+    #   drf-yasg
+    #   edx-api-doc-tools
+    #   edx-auth-backends
+    #   edx-django-release-util
 djangorestframework-expander==0.2.3
     # via -r requirements/base.in
-djangorestframework==3.12.2
-    # via -r requirements/base.in, djangorestframework-expander, drf-nested-routers, drf-yasg, edx-api-doc-tools
+djangorestframework==3.12.4
+    # via
+    #   -r requirements/base.in
+    #   djangorestframework-expander
+    #   drf-nested-routers
+    #   drf-yasg
+    #   edx-api-doc-tools
 git+https://github.com/alanjds/drf-nested-routers.git@8686392f91b114e01f3781807dea60e9a80d3e07#egg=drf-nested-routers==0.91
     # via -r requirements/github.in
 drf-yasg==1.20.0
     # via edx-api-doc-tools
 edx-api-doc-tools==1.4.0
     # via -r requirements/base.in
-edx-auth-backends==3.1.0
+edx-auth-backends==3.3.3
     # via -r requirements/base.in
-edx-django-release-util==0.4.4
+edx-django-release-util==1.0.0
     # via -r requirements/base.in
 idna==2.10
     # via requests
@@ -50,47 +76,68 @@ inflection==0.5.1
     # via drf-yasg
 itypes==1.2.0
     # via coreapi
-jinja2==2.11.2
+jinja2==3.0.1
     # via coreschema
-markupsafe==1.1.1
+markupsafe==2.0.1
     # via jinja2
 mysqlclient==1.3.14
-    # via -c requirements/constraints.txt, -r requirements/base.in
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
 oauthlib==3.1.0
-    # via requests-oauthlib, social-auth-core
-packaging==20.4
+    # via
+    #   requests-oauthlib
+    #   social-auth-core
+packaging==20.9
     # via drf-yasg
 pyblake2==1.1.2
     # via -r requirements/base.in
 pycparser==2.20
     # via cffi
-pyjwt==1.7.1
-    # via edx-auth-backends, social-auth-core
+pyjwt==2.1.0
+    # via
+    #   edx-auth-backends
+    #   social-auth-core
 pyparsing==2.4.7
     # via packaging
 python3-openid==3.2.0
     # via social-auth-core
-pytz==2020.4
-    # via -r requirements/base.in, django
-pyyaml==5.3.1
+pytz==2021.1
+    # via
+    #   -r requirements/base.in
+    #   django
+pyyaml==5.4.1
     # via edx-django-release-util
 requests-oauthlib==1.3.0
     # via social-auth-core
-requests==2.24.0
-    # via coreapi, requests-oauthlib, social-auth-core
+requests==2.25.1
+    # via
+    #   coreapi
+    #   requests-oauthlib
+    #   social-auth-core
 ruamel.yaml.clib==0.2.2
     # via ruamel.yaml
-ruamel.yaml==0.16.12
+ruamel.yaml==0.17.4
     # via drf-yasg
-six==1.15.0
-    # via cryptography, edx-auth-backends, edx-django-release-util, packaging, social-auth-app-django, social-auth-core
+six==1.16.0
+    # via
+    #   cryptography
+    #   edx-auth-backends
+    #   edx-django-release-util
+    #   social-auth-app-django
 social-auth-app-django==4.0.0
     # via edx-auth-backends
-social-auth-core==3.3.3
-    # via edx-auth-backends, social-auth-app-django
+social-auth-core==4.1.0
+    # via
+    #   edx-auth-backends
+    #   social-auth-app-django
 sqlparse==0.4.1
-    # via -r requirements/base.in, django
+    # via
+    #   -r requirements/base.in
+    #   django
 uritemplate==3.0.1
-    # via coreapi, drf-yasg
-urllib3==1.25.11
+    # via
+    #   coreapi
+    #   drf-yasg
+urllib3==1.26.4
     # via requests

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -22,3 +22,12 @@ django-filter==2.1.0
 mysqlclient==1.3.14
 
 pip-tools<6.0
+
+# We want >=3.3.2 to fix a moderate-severity security issue
+# reported here: https://github.com/pyca/cryptography/issues/5615.
+# However, we want <3.4 because the usage of Rust in cryptography>=3.4
+# causes the package to fail to install on the Alpine Linux image used for CI.
+# When someone has the time to switch that image to Ubuntu, then we can probably
+# remove this pin (as far as I can tell, there is no production reason not to
+# upgrade to the latest version of this package).
+cryptography>=3.3.2,<3.4

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,8 +8,6 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
-attrs<19.0.0
-
 boto3<2.0
 
 # Not yet using Django 3.X. Using the 2.X LTS to mirror the LMS.
@@ -20,10 +18,6 @@ django-cors-headers>=2.2.0,<2.3
 django-environ==0.4.5
 
 django-filter==2.1.0
-
-# factory-boy version 3.0.0 is having installation problems
-# in docker images https://github.com/FactoryBoy/factory_boy/issues/780
-factory-boy<3.0.0
 
 mysqlclient==1.3.14
 

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -6,41 +6,45 @@
 #
 alabaster==0.7.12
     # via sphinx
-babel==2.8.0
+babel==2.9.1
     # via sphinx
-certifi==2020.11.8
+certifi==2020.12.5
     # via requests
-chardet==3.0.4
+chardet==4.0.0
     # via requests
-docutils==0.16
+docutils==0.17.1
     # via sphinx
-edx-sphinx-theme==1.5.0
+edx-sphinx-theme==2.1.0
     # via -r requirements/docs.in
 idna==2.10
     # via requests
 imagesize==1.2.0
     # via sphinx
-jinja2==2.11.2
+jinja2==3.0.1
     # via sphinx
-markupsafe==1.1.1
+markupsafe==2.0.1
     # via jinja2
-pygments==2.7.2
+pygments==2.9.0
     # via sphinx
-pytz==2020.4
+pytz==2021.1
     # via babel
-requests==2.24.0
+requests==2.25.1
     # via sphinx
-six==1.15.0
-    # via edx-sphinx-theme, sphinx
-snowballstemmer==2.0.0
+six==1.16.0
+    # via
+    #   edx-sphinx-theme
+    #   sphinx
+snowballstemmer==2.1.0
     # via sphinx
 sphinx==1.6.7
-    # via -r requirements/docs.in, edx-sphinx-theme
-sphinxcontrib-serializinghtml==1.1.4
+    # via
+    #   -r requirements/docs.in
+    #   edx-sphinx-theme
+sphinxcontrib-serializinghtml==1.1.5
     # via sphinxcontrib-websupport
 sphinxcontrib-websupport==1.2.4
     # via sphinx
-urllib3==1.25.11
+urllib3==1.26.4
     # via requests
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -4,25 +4,44 @@
 #
 #    make upgrade
 #
-alabaster==0.7.12         # via sphinx
-babel==2.8.0              # via sphinx
-certifi==2020.11.8        # via requests
-chardet==3.0.4            # via requests
-docutils==0.16            # via sphinx
-edx-sphinx-theme==1.5.0   # via -r requirements/docs.in
-idna==2.10                # via requests
-imagesize==1.2.0          # via sphinx
-jinja2==2.11.2            # via sphinx
-markupsafe==1.1.1         # via jinja2
-pygments==2.7.2           # via sphinx
-pytz==2020.4              # via babel
-requests==2.24.0          # via sphinx
-six==1.15.0               # via edx-sphinx-theme, sphinx
-snowballstemmer==2.0.0    # via sphinx
-sphinx==1.6.7             # via -r requirements/docs.in, edx-sphinx-theme
-sphinxcontrib-serializinghtml==1.1.4  # via sphinxcontrib-websupport
-sphinxcontrib-websupport==1.2.4  # via sphinx
-urllib3==1.25.11          # via requests
+alabaster==0.7.12
+    # via sphinx
+babel==2.8.0
+    # via sphinx
+certifi==2020.11.8
+    # via requests
+chardet==3.0.4
+    # via requests
+docutils==0.16
+    # via sphinx
+edx-sphinx-theme==1.5.0
+    # via -r requirements/docs.in
+idna==2.10
+    # via requests
+imagesize==1.2.0
+    # via sphinx
+jinja2==2.11.2
+    # via sphinx
+markupsafe==1.1.1
+    # via jinja2
+pygments==2.7.2
+    # via sphinx
+pytz==2020.4
+    # via babel
+requests==2.24.0
+    # via sphinx
+six==1.15.0
+    # via edx-sphinx-theme, sphinx
+snowballstemmer==2.0.0
+    # via sphinx
+sphinx==1.6.7
+    # via -r requirements/docs.in, edx-sphinx-theme
+sphinxcontrib-serializinghtml==1.1.4
+    # via sphinxcontrib-websupport
+sphinxcontrib-websupport==1.2.4
+    # via sphinx
+urllib3==1.25.11
+    # via requests
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -5,185 +5,407 @@
 #    make upgrade
 #
 alabaster==0.7.12
-    # via -r requirements/docs.txt, sphinx
-astroid==2.3.3
-    # via -r requirements/test.txt, pylint, pylint-celery
-attrs==18.2.0
-    # via -c requirements/constraints.txt, -r requirements/test.txt, pytest
-babel==2.8.0
-    # via -r requirements/docs.txt, sphinx
-certifi==2020.11.8
-    # via -r requirements/docs.txt, -r requirements/test.txt, requests
-cffi==1.14.3
-    # via -r requirements/test.txt, cryptography
-chardet==3.0.4
-    # via -r requirements/docs.txt, -r requirements/test.txt, requests
+    # via
+    #   -r requirements/docs.txt
+    #   sphinx
+astroid==2.5.6
+    # via
+    #   -r requirements/test.txt
+    #   pylint
+    #   pylint-celery
+attrs==21.2.0
+    # via
+    #   -r requirements/test.txt
+    #   pytest
+babel==2.9.1
+    # via
+    #   -r requirements/docs.txt
+    #   sphinx
+certifi==2020.12.5
+    # via
+    #   -r requirements/docs.txt
+    #   -r requirements/test.txt
+    #   requests
+cffi==1.14.5
+    # via
+    #   -r requirements/test.txt
+    #   cryptography
+chardet==4.0.0
+    # via
+    #   -r requirements/docs.txt
+    #   -r requirements/test.txt
+    #   diff-cover
+    #   requests
 click-log==0.3.2
-    # via -r requirements/test.txt, edx-lint
-click==7.1.2
-    # via -r requirements/test.txt, click-log, edx-lint
+    # via
+    #   -r requirements/test.txt
+    #   edx-lint
+click==8.0.1
+    # via
+    #   -r requirements/test.txt
+    #   click-log
+    #   code-annotations
+    #   edx-lint
+code-annotations==1.1.2
+    # via
+    #   -r requirements/test.txt
+    #   edx-lint
 coreapi==2.3.3
-    # via -r requirements/test.txt, drf-yasg
+    # via
+    #   -r requirements/test.txt
+    #   drf-yasg
 coreschema==0.0.4
-    # via -r requirements/test.txt, coreapi, drf-yasg
-coverage==5.3
-    # via -r requirements/test.txt, pytest-cov
-cryptography==3.2.1
-    # via -r requirements/test.txt, social-auth-core
-ddt==1.4.1
+    # via
+    #   -r requirements/test.txt
+    #   coreapi
+    #   drf-yasg
+coverage[toml]==5.5
+    # via
+    #   -r requirements/test.txt
+    #   pytest-cov
+cryptography==3.3.2
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
+    #   social-auth-core
+ddt==1.4.2
     # via -r requirements/test.txt
-defusedxml==0.6.0
-    # via -r requirements/test.txt, python3-openid, social-auth-core
-diff-cover==4.0.1
+defusedxml==0.7.1
+    # via
+    #   -r requirements/test.txt
+    #   python3-openid
+    #   social-auth-core
+diff-cover==5.1.1
     # via -r requirements/test.txt
 django-cors-headers==2.2.1
-    # via -c requirements/constraints.txt, -r requirements/test.txt
-django-debug-toolbar==3.1.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
+django-debug-toolbar==3.2.1
     # via -r requirements/local.in
-django-dynamic-fixture==3.1.0
+django-dynamic-fixture==3.1.1
     # via -r requirements/test.txt
 django-environ==0.4.5
-    # via -c requirements/constraints.txt, -r requirements/test.txt
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
 django-filter==2.1.0
-    # via -c requirements/constraints.txt, -r requirements/test.txt
-django-waffle==2.0.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
+django-waffle==2.2.0
     # via -r requirements/test.txt
-django==2.2.17
-    # via -c requirements/constraints.txt, -r requirements/test.txt, django-debug-toolbar, django-filter, djangorestframework, drf-nested-routers, drf-yasg, edx-api-doc-tools, edx-auth-backends, edx-django-release-util
+django==2.2.23
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
+    #   django-debug-toolbar
+    #   django-filter
+    #   djangorestframework
+    #   drf-nested-routers
+    #   drf-yasg
+    #   edx-api-doc-tools
+    #   edx-auth-backends
+    #   edx-django-release-util
+    #   edx-lint
 djangorestframework-expander==0.2.3
     # via -r requirements/test.txt
-djangorestframework==3.12.2
-    # via -r requirements/test.txt, djangorestframework-expander, drf-nested-routers, drf-yasg, edx-api-doc-tools
-docutils==0.16
-    # via -r requirements/docs.txt, sphinx
+djangorestframework==3.12.4
+    # via
+    #   -r requirements/test.txt
+    #   djangorestframework-expander
+    #   drf-nested-routers
+    #   drf-yasg
+    #   edx-api-doc-tools
+docutils==0.17.1
+    # via
+    #   -r requirements/docs.txt
+    #   sphinx
 git+https://github.com/alanjds/drf-nested-routers.git@8686392f91b114e01f3781807dea60e9a80d3e07#egg=drf-nested-routers==0.91
     # via -r requirements/test.txt
 drf-yasg==1.20.0
-    # via -r requirements/test.txt, edx-api-doc-tools
+    # via
+    #   -r requirements/test.txt
+    #   edx-api-doc-tools
 edx-api-doc-tools==1.4.0
     # via -r requirements/test.txt
-edx-auth-backends==3.1.0
+edx-auth-backends==3.3.3
     # via -r requirements/test.txt
-edx-django-release-util==0.4.4
+edx-django-release-util==1.0.0
     # via -r requirements/test.txt
-edx-lint==1.5.2
+edx-lint==5.0.0
     # via -r requirements/test.txt
-edx-sphinx-theme==1.5.0
+edx-sphinx-theme==2.1.0
     # via -r requirements/docs.txt
-factory-boy==2.12.0
-    # via -c requirements/constraints.txt, -r requirements/test.txt
-faker==4.14.2
-    # via -r requirements/test.txt, factory-boy
+factory-boy==3.2.0
+    # via -r requirements/test.txt
+faker==8.2.1
+    # via
+    #   -r requirements/test.txt
+    #   factory-boy
 idna==2.10
-    # via -r requirements/docs.txt, -r requirements/test.txt, requests
+    # via
+    #   -r requirements/docs.txt
+    #   -r requirements/test.txt
+    #   requests
 imagesize==1.2.0
-    # via -r requirements/docs.txt, sphinx
-inflect==4.1.0
-    # via -r requirements/test.txt, jinja2-pluralize
+    # via
+    #   -r requirements/docs.txt
+    #   sphinx
+inflect==5.3.0
+    # via
+    #   -r requirements/test.txt
+    #   jinja2-pluralize
 inflection==0.5.1
-    # via -r requirements/test.txt, drf-yasg
+    # via
+    #   -r requirements/test.txt
+    #   drf-yasg
 iniconfig==1.1.1
-    # via -r requirements/test.txt, pytest
-isort==4.3.21
-    # via -r requirements/test.txt, pylint
+    # via
+    #   -r requirements/test.txt
+    #   pytest
+isort==5.8.0
+    # via
+    #   -r requirements/test.txt
+    #   pylint
 itypes==1.2.0
-    # via -r requirements/test.txt, coreapi
+    # via
+    #   -r requirements/test.txt
+    #   coreapi
 jinja2-pluralize==0.3.0
-    # via -r requirements/test.txt, diff-cover
-jinja2==2.11.2
-    # via -r requirements/docs.txt, -r requirements/test.txt, coreschema, diff-cover, jinja2-pluralize, sphinx
-lazy-object-proxy==1.4.3
-    # via -r requirements/test.txt, astroid
-markupsafe==1.1.1
-    # via -r requirements/docs.txt, -r requirements/test.txt, jinja2
+    # via
+    #   -r requirements/test.txt
+    #   diff-cover
+jinja2==3.0.1
+    # via
+    #   -r requirements/docs.txt
+    #   -r requirements/test.txt
+    #   code-annotations
+    #   coreschema
+    #   diff-cover
+    #   jinja2-pluralize
+    #   sphinx
+lazy-object-proxy==1.6.0
+    # via
+    #   -r requirements/test.txt
+    #   astroid
+markupsafe==2.0.1
+    # via
+    #   -r requirements/docs.txt
+    #   -r requirements/test.txt
+    #   jinja2
 mccabe==0.6.1
-    # via -r requirements/test.txt, pylint
+    # via
+    #   -r requirements/test.txt
+    #   pylint
 mypy-extensions==0.4.3
-    # via -r requirements/test.txt, mypy
-mypy==0.790
+    # via
+    #   -r requirements/test.txt
+    #   mypy
+mypy==0.812
     # via -r requirements/test.txt
 mysqlclient==1.3.14
-    # via -c requirements/constraints.txt, -r requirements/test.txt
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
 oauthlib==3.1.0
-    # via -r requirements/test.txt, requests-oauthlib, social-auth-core
-packaging==20.4
-    # via -r requirements/test.txt, drf-yasg, pytest
+    # via
+    #   -r requirements/test.txt
+    #   requests-oauthlib
+    #   social-auth-core
+packaging==20.9
+    # via
+    #   -r requirements/test.txt
+    #   drf-yasg
+    #   pytest
+pbr==5.6.0
+    # via
+    #   -r requirements/test.txt
+    #   stevedore
 pluggy==0.13.1
-    # via -r requirements/test.txt, diff-cover, pytest
-py==1.9.0
-    # via -r requirements/test.txt, pytest
+    # via
+    #   -r requirements/test.txt
+    #   diff-cover
+    #   pytest
+py==1.10.0
+    # via
+    #   -r requirements/test.txt
+    #   pytest
 pyblake2==1.1.2
     # via -r requirements/test.txt
-pycodestyle==2.6.0
+pycodestyle==2.7.0
     # via -r requirements/test.txt
 pycparser==2.20
-    # via -r requirements/test.txt, cffi
-pygments==2.7.2
-    # via -r requirements/docs.txt, -r requirements/test.txt, diff-cover, sphinx
-pyjwt==1.7.1
-    # via -r requirements/test.txt, edx-auth-backends, social-auth-core
+    # via
+    #   -r requirements/test.txt
+    #   cffi
+pygments==2.9.0
+    # via
+    #   -r requirements/docs.txt
+    #   -r requirements/test.txt
+    #   diff-cover
+    #   sphinx
+pyjwt==2.1.0
+    # via
+    #   -r requirements/test.txt
+    #   edx-auth-backends
+    #   social-auth-core
 pylint-celery==0.3
-    # via -r requirements/test.txt, edx-lint
-pylint-django==2.0.11
-    # via -r requirements/test.txt, edx-lint
+    # via
+    #   -r requirements/test.txt
+    #   edx-lint
+pylint-django==2.4.4
+    # via
+    #   -r requirements/test.txt
+    #   edx-lint
 pylint-plugin-utils==0.6
-    # via -r requirements/test.txt, pylint-celery, pylint-django
-pylint==2.4.4
-    # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+    # via
+    #   -r requirements/test.txt
+    #   pylint-celery
+    #   pylint-django
+pylint==2.8.2
+    # via
+    #   -r requirements/test.txt
+    #   edx-lint
+    #   pylint-celery
+    #   pylint-django
+    #   pylint-plugin-utils
 pyparsing==2.4.7
-    # via -r requirements/test.txt, packaging
-pytest-cov==2.10.1
+    # via
+    #   -r requirements/test.txt
+    #   packaging
+pytest-cov==2.12.0
     # via -r requirements/test.txt
-pytest-django==4.1.0
+pytest-django==4.3.0
     # via -r requirements/test.txt
-pytest==6.1.2
-    # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest==6.2.4
+    # via
+    #   -r requirements/test.txt
+    #   pytest-cov
+    #   pytest-django
 python-dateutil==2.8.1
-    # via -r requirements/test.txt, faker
+    # via
+    #   -r requirements/test.txt
+    #   faker
+python-slugify==5.0.2
+    # via
+    #   -r requirements/test.txt
+    #   code-annotations
 python3-openid==3.2.0
-    # via -r requirements/test.txt, social-auth-core
-pytz==2020.4
-    # via -r requirements/docs.txt, -r requirements/test.txt, babel, django
-pyyaml==5.3.1
-    # via -r requirements/test.txt, edx-django-release-util
+    # via
+    #   -r requirements/test.txt
+    #   social-auth-core
+pytz==2021.1
+    # via
+    #   -r requirements/docs.txt
+    #   -r requirements/test.txt
+    #   babel
+    #   django
+pyyaml==5.4.1
+    # via
+    #   -r requirements/test.txt
+    #   code-annotations
+    #   edx-django-release-util
 requests-oauthlib==1.3.0
-    # via -r requirements/test.txt, social-auth-core
-requests==2.24.0
-    # via -r requirements/docs.txt, -r requirements/test.txt, coreapi, requests-oauthlib, social-auth-core, sphinx
+    # via
+    #   -r requirements/test.txt
+    #   social-auth-core
+requests==2.25.1
+    # via
+    #   -r requirements/docs.txt
+    #   -r requirements/test.txt
+    #   coreapi
+    #   requests-oauthlib
+    #   social-auth-core
+    #   sphinx
 ruamel.yaml.clib==0.2.2
-    # via -r requirements/test.txt, ruamel.yaml
-ruamel.yaml==0.16.12
-    # via -r requirements/test.txt, drf-yasg
-six==1.15.0
-    # via -r requirements/docs.txt, -r requirements/test.txt, astroid, cryptography, django-dynamic-fixture, edx-auth-backends, edx-django-release-util, edx-lint, edx-sphinx-theme, packaging, python-dateutil, social-auth-app-django, social-auth-core, sphinx
-snowballstemmer==2.0.0
-    # via -r requirements/docs.txt, sphinx
+    # via
+    #   -r requirements/test.txt
+    #   ruamel.yaml
+ruamel.yaml==0.17.4
+    # via
+    #   -r requirements/test.txt
+    #   drf-yasg
+six==1.16.0
+    # via
+    #   -r requirements/docs.txt
+    #   -r requirements/test.txt
+    #   cryptography
+    #   django-dynamic-fixture
+    #   edx-auth-backends
+    #   edx-django-release-util
+    #   edx-lint
+    #   edx-sphinx-theme
+    #   python-dateutil
+    #   social-auth-app-django
+    #   sphinx
+snowballstemmer==2.1.0
+    # via
+    #   -r requirements/docs.txt
+    #   sphinx
 social-auth-app-django==4.0.0
-    # via -r requirements/test.txt, edx-auth-backends
-social-auth-core==3.3.3
-    # via -r requirements/test.txt, edx-auth-backends, social-auth-app-django
+    # via
+    #   -r requirements/test.txt
+    #   edx-auth-backends
+social-auth-core==4.1.0
+    # via
+    #   -r requirements/test.txt
+    #   edx-auth-backends
+    #   social-auth-app-django
 sphinx==1.6.7
-    # via -r requirements/docs.txt, edx-sphinx-theme
-sphinxcontrib-serializinghtml==1.1.4
-    # via -r requirements/docs.txt, sphinxcontrib-websupport
+    # via
+    #   -r requirements/docs.txt
+    #   edx-sphinx-theme
+sphinxcontrib-serializinghtml==1.1.5
+    # via
+    #   -r requirements/docs.txt
+    #   sphinxcontrib-websupport
 sphinxcontrib-websupport==1.2.4
-    # via -r requirements/docs.txt, sphinx
+    # via
+    #   -r requirements/docs.txt
+    #   sphinx
 sqlparse==0.4.1
-    # via -r requirements/test.txt, django, django-debug-toolbar
+    # via
+    #   -r requirements/test.txt
+    #   django
+    #   django-debug-toolbar
+stevedore==3.3.0
+    # via
+    #   -r requirements/test.txt
+    #   code-annotations
 text-unidecode==1.3
-    # via -r requirements/test.txt, faker
+    # via
+    #   -r requirements/test.txt
+    #   faker
+    #   python-slugify
 toml==0.10.2
-    # via -r requirements/test.txt, pytest
-typed-ast==1.4.1
-    # via -r requirements/test.txt, mypy
-typing-extensions==3.7.4.3
-    # via -r requirements/test.txt, mypy
+    # via
+    #   -r requirements/test.txt
+    #   coverage
+    #   pylint
+    #   pytest
+typed-ast==1.4.3
+    # via
+    #   -r requirements/test.txt
+    #   mypy
+typing-extensions==3.10.0.0
+    # via
+    #   -r requirements/test.txt
+    #   mypy
 uritemplate==3.0.1
-    # via -r requirements/test.txt, coreapi, drf-yasg
-urllib3==1.25.11
-    # via -r requirements/docs.txt, -r requirements/test.txt, requests
-wrapt==1.11.2
-    # via -r requirements/test.txt, astroid
+    # via
+    #   -r requirements/test.txt
+    #   coreapi
+    #   drf-yasg
+urllib3==1.26.4
+    # via
+    #   -r requirements/docs.txt
+    #   -r requirements/test.txt
+    #   requests
+wrapt==1.12.1
+    # via
+    #   -r requirements/test.txt
+    #   astroid
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -4,96 +4,186 @@
 #
 #    make upgrade
 #
-alabaster==0.7.12         # via -r requirements/docs.txt, sphinx
-astroid==2.3.3            # via -r requirements/test.txt, pylint, pylint-celery
-attrs==18.2.0             # via -c requirements/constraints.txt, -r requirements/test.txt, pytest
-babel==2.8.0              # via -r requirements/docs.txt, sphinx
-certifi==2020.11.8        # via -r requirements/docs.txt, -r requirements/test.txt, requests
-cffi==1.14.3              # via -r requirements/test.txt, cryptography
-chardet==3.0.4            # via -r requirements/docs.txt, -r requirements/test.txt, requests
-click-log==0.3.2          # via -r requirements/test.txt, edx-lint
-click==7.1.2              # via -r requirements/test.txt, click-log, edx-lint
-coreapi==2.3.3            # via -r requirements/test.txt, drf-yasg
-coreschema==0.0.4         # via -r requirements/test.txt, coreapi, drf-yasg
-coverage==5.3             # via -r requirements/test.txt, pytest-cov
-cryptography==3.2.1       # via -r requirements/test.txt, social-auth-core
-ddt==1.4.1                # via -r requirements/test.txt
-defusedxml==0.6.0         # via -r requirements/test.txt, python3-openid, social-auth-core
-diff-cover==4.0.1         # via -r requirements/test.txt
-django-cors-headers==2.2.1  # via -c requirements/constraints.txt, -r requirements/test.txt
-django-debug-toolbar==3.1.1  # via -r requirements/local.in
-django-dynamic-fixture==3.1.0  # via -r requirements/test.txt
-django-environ==0.4.5     # via -c requirements/constraints.txt, -r requirements/test.txt
-django-filter==2.1.0      # via -c requirements/constraints.txt, -r requirements/test.txt
-django-waffle==2.0.0      # via -r requirements/test.txt
-django==2.2.17            # via -c requirements/constraints.txt, -r requirements/test.txt, django-debug-toolbar, django-filter, djangorestframework, drf-nested-routers, drf-yasg, edx-api-doc-tools, edx-auth-backends, edx-django-release-util
-djangorestframework-expander==0.2.3  # via -r requirements/test.txt
-djangorestframework==3.12.2  # via -r requirements/test.txt, djangorestframework-expander, drf-nested-routers, drf-yasg, edx-api-doc-tools
-docutils==0.16            # via -r requirements/docs.txt, sphinx
-git+https://github.com/alanjds/drf-nested-routers.git@8686392f91b114e01f3781807dea60e9a80d3e07#egg=drf-nested-routers==0.91  # via -r requirements/test.txt
-drf-yasg==1.20.0          # via -r requirements/test.txt, edx-api-doc-tools
-edx-api-doc-tools==1.4.0  # via -r requirements/test.txt
-edx-auth-backends==3.1.0  # via -r requirements/test.txt
-edx-django-release-util==0.4.4  # via -r requirements/test.txt
-edx-lint==1.5.2           # via -r requirements/test.txt
-edx-sphinx-theme==1.5.0   # via -r requirements/docs.txt
-factory-boy==2.12.0       # via -c requirements/constraints.txt, -r requirements/test.txt
-faker==4.14.2             # via -r requirements/test.txt, factory-boy
-idna==2.10                # via -r requirements/docs.txt, -r requirements/test.txt, requests
-imagesize==1.2.0          # via -r requirements/docs.txt, sphinx
-inflect==4.1.0            # via -r requirements/test.txt, jinja2-pluralize
-inflection==0.5.1         # via -r requirements/test.txt, drf-yasg
-iniconfig==1.1.1          # via -r requirements/test.txt, pytest
-isort==4.3.21             # via -r requirements/test.txt, pylint
-itypes==1.2.0             # via -r requirements/test.txt, coreapi
-jinja2-pluralize==0.3.0   # via -r requirements/test.txt, diff-cover
-jinja2==2.11.2            # via -r requirements/docs.txt, -r requirements/test.txt, coreschema, diff-cover, jinja2-pluralize, sphinx
-lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
-markupsafe==1.1.1         # via -r requirements/docs.txt, -r requirements/test.txt, jinja2
-mccabe==0.6.1             # via -r requirements/test.txt, pylint
-mypy-extensions==0.4.3    # via -r requirements/test.txt, mypy
-mypy==0.790               # via -r requirements/test.txt
-mysqlclient==1.3.14       # via -c requirements/constraints.txt, -r requirements/test.txt
-oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib, social-auth-core
-packaging==20.4           # via -r requirements/test.txt, drf-yasg, pytest
-pluggy==0.13.1            # via -r requirements/test.txt, diff-cover, pytest
-py==1.9.0                 # via -r requirements/test.txt, pytest
-pyblake2==1.1.2           # via -r requirements/test.txt
-pycodestyle==2.6.0        # via -r requirements/test.txt
-pycparser==2.20           # via -r requirements/test.txt, cffi
-pygments==2.7.2           # via -r requirements/docs.txt, -r requirements/test.txt, diff-cover, sphinx
-pyjwt==1.7.1              # via -r requirements/test.txt, edx-auth-backends, social-auth-core
-pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
-pylint-django==2.0.11     # via -r requirements/test.txt, edx-lint
-pylint-plugin-utils==0.6  # via -r requirements/test.txt, pylint-celery, pylint-django
-pylint==2.4.4             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pyparsing==2.4.7          # via -r requirements/test.txt, packaging
-pytest-cov==2.10.1        # via -r requirements/test.txt
-pytest-django==4.1.0      # via -r requirements/test.txt
-pytest==6.1.2             # via -r requirements/test.txt, pytest-cov, pytest-django
-python-dateutil==2.8.1    # via -r requirements/test.txt, faker
-python3-openid==3.2.0     # via -r requirements/test.txt, social-auth-core
-pytz==2020.4              # via -r requirements/docs.txt, -r requirements/test.txt, babel, django
-pyyaml==5.3.1             # via -r requirements/test.txt, edx-django-release-util
-requests-oauthlib==1.3.0  # via -r requirements/test.txt, social-auth-core
-requests==2.24.0          # via -r requirements/docs.txt, -r requirements/test.txt, coreapi, requests-oauthlib, social-auth-core, sphinx
-ruamel.yaml.clib==0.2.2   # via -r requirements/test.txt, ruamel.yaml
-ruamel.yaml==0.16.12      # via -r requirements/test.txt, drf-yasg
-six==1.15.0               # via -r requirements/docs.txt, -r requirements/test.txt, astroid, cryptography, django-dynamic-fixture, edx-auth-backends, edx-django-release-util, edx-lint, edx-sphinx-theme, packaging, python-dateutil, social-auth-app-django, social-auth-core, sphinx
-snowballstemmer==2.0.0    # via -r requirements/docs.txt, sphinx
-social-auth-app-django==4.0.0  # via -r requirements/test.txt, edx-auth-backends
-social-auth-core==3.3.3   # via -r requirements/test.txt, edx-auth-backends, social-auth-app-django
-sphinx==1.6.7             # via -r requirements/docs.txt, edx-sphinx-theme
-sphinxcontrib-serializinghtml==1.1.4  # via -r requirements/docs.txt, sphinxcontrib-websupport
-sphinxcontrib-websupport==1.2.4  # via -r requirements/docs.txt, sphinx
-sqlparse==0.4.1           # via -r requirements/test.txt, django, django-debug-toolbar
-text-unidecode==1.3       # via -r requirements/test.txt, faker
-toml==0.10.2              # via -r requirements/test.txt, pytest
-typed-ast==1.4.1          # via -r requirements/test.txt, mypy
-typing-extensions==3.7.4.3  # via -r requirements/test.txt, mypy
-uritemplate==3.0.1        # via -r requirements/test.txt, coreapi, drf-yasg
-urllib3==1.25.11          # via -r requirements/docs.txt, -r requirements/test.txt, requests
-wrapt==1.11.2             # via -r requirements/test.txt, astroid
+alabaster==0.7.12
+    # via -r requirements/docs.txt, sphinx
+astroid==2.3.3
+    # via -r requirements/test.txt, pylint, pylint-celery
+attrs==18.2.0
+    # via -c requirements/constraints.txt, -r requirements/test.txt, pytest
+babel==2.8.0
+    # via -r requirements/docs.txt, sphinx
+certifi==2020.11.8
+    # via -r requirements/docs.txt, -r requirements/test.txt, requests
+cffi==1.14.3
+    # via -r requirements/test.txt, cryptography
+chardet==3.0.4
+    # via -r requirements/docs.txt, -r requirements/test.txt, requests
+click-log==0.3.2
+    # via -r requirements/test.txt, edx-lint
+click==7.1.2
+    # via -r requirements/test.txt, click-log, edx-lint
+coreapi==2.3.3
+    # via -r requirements/test.txt, drf-yasg
+coreschema==0.0.4
+    # via -r requirements/test.txt, coreapi, drf-yasg
+coverage==5.3
+    # via -r requirements/test.txt, pytest-cov
+cryptography==3.2.1
+    # via -r requirements/test.txt, social-auth-core
+ddt==1.4.1
+    # via -r requirements/test.txt
+defusedxml==0.6.0
+    # via -r requirements/test.txt, python3-openid, social-auth-core
+diff-cover==4.0.1
+    # via -r requirements/test.txt
+django-cors-headers==2.2.1
+    # via -c requirements/constraints.txt, -r requirements/test.txt
+django-debug-toolbar==3.1.1
+    # via -r requirements/local.in
+django-dynamic-fixture==3.1.0
+    # via -r requirements/test.txt
+django-environ==0.4.5
+    # via -c requirements/constraints.txt, -r requirements/test.txt
+django-filter==2.1.0
+    # via -c requirements/constraints.txt, -r requirements/test.txt
+django-waffle==2.0.0
+    # via -r requirements/test.txt
+django==2.2.17
+    # via -c requirements/constraints.txt, -r requirements/test.txt, django-debug-toolbar, django-filter, djangorestframework, drf-nested-routers, drf-yasg, edx-api-doc-tools, edx-auth-backends, edx-django-release-util
+djangorestframework-expander==0.2.3
+    # via -r requirements/test.txt
+djangorestframework==3.12.2
+    # via -r requirements/test.txt, djangorestframework-expander, drf-nested-routers, drf-yasg, edx-api-doc-tools
+docutils==0.16
+    # via -r requirements/docs.txt, sphinx
+git+https://github.com/alanjds/drf-nested-routers.git@8686392f91b114e01f3781807dea60e9a80d3e07#egg=drf-nested-routers==0.91
+    # via -r requirements/test.txt
+drf-yasg==1.20.0
+    # via -r requirements/test.txt, edx-api-doc-tools
+edx-api-doc-tools==1.4.0
+    # via -r requirements/test.txt
+edx-auth-backends==3.1.0
+    # via -r requirements/test.txt
+edx-django-release-util==0.4.4
+    # via -r requirements/test.txt
+edx-lint==1.5.2
+    # via -r requirements/test.txt
+edx-sphinx-theme==1.5.0
+    # via -r requirements/docs.txt
+factory-boy==2.12.0
+    # via -c requirements/constraints.txt, -r requirements/test.txt
+faker==4.14.2
+    # via -r requirements/test.txt, factory-boy
+idna==2.10
+    # via -r requirements/docs.txt, -r requirements/test.txt, requests
+imagesize==1.2.0
+    # via -r requirements/docs.txt, sphinx
+inflect==4.1.0
+    # via -r requirements/test.txt, jinja2-pluralize
+inflection==0.5.1
+    # via -r requirements/test.txt, drf-yasg
+iniconfig==1.1.1
+    # via -r requirements/test.txt, pytest
+isort==4.3.21
+    # via -r requirements/test.txt, pylint
+itypes==1.2.0
+    # via -r requirements/test.txt, coreapi
+jinja2-pluralize==0.3.0
+    # via -r requirements/test.txt, diff-cover
+jinja2==2.11.2
+    # via -r requirements/docs.txt, -r requirements/test.txt, coreschema, diff-cover, jinja2-pluralize, sphinx
+lazy-object-proxy==1.4.3
+    # via -r requirements/test.txt, astroid
+markupsafe==1.1.1
+    # via -r requirements/docs.txt, -r requirements/test.txt, jinja2
+mccabe==0.6.1
+    # via -r requirements/test.txt, pylint
+mypy-extensions==0.4.3
+    # via -r requirements/test.txt, mypy
+mypy==0.790
+    # via -r requirements/test.txt
+mysqlclient==1.3.14
+    # via -c requirements/constraints.txt, -r requirements/test.txt
+oauthlib==3.1.0
+    # via -r requirements/test.txt, requests-oauthlib, social-auth-core
+packaging==20.4
+    # via -r requirements/test.txt, drf-yasg, pytest
+pluggy==0.13.1
+    # via -r requirements/test.txt, diff-cover, pytest
+py==1.9.0
+    # via -r requirements/test.txt, pytest
+pyblake2==1.1.2
+    # via -r requirements/test.txt
+pycodestyle==2.6.0
+    # via -r requirements/test.txt
+pycparser==2.20
+    # via -r requirements/test.txt, cffi
+pygments==2.7.2
+    # via -r requirements/docs.txt, -r requirements/test.txt, diff-cover, sphinx
+pyjwt==1.7.1
+    # via -r requirements/test.txt, edx-auth-backends, social-auth-core
+pylint-celery==0.3
+    # via -r requirements/test.txt, edx-lint
+pylint-django==2.0.11
+    # via -r requirements/test.txt, edx-lint
+pylint-plugin-utils==0.6
+    # via -r requirements/test.txt, pylint-celery, pylint-django
+pylint==2.4.4
+    # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pyparsing==2.4.7
+    # via -r requirements/test.txt, packaging
+pytest-cov==2.10.1
+    # via -r requirements/test.txt
+pytest-django==4.1.0
+    # via -r requirements/test.txt
+pytest==6.1.2
+    # via -r requirements/test.txt, pytest-cov, pytest-django
+python-dateutil==2.8.1
+    # via -r requirements/test.txt, faker
+python3-openid==3.2.0
+    # via -r requirements/test.txt, social-auth-core
+pytz==2020.4
+    # via -r requirements/docs.txt, -r requirements/test.txt, babel, django
+pyyaml==5.3.1
+    # via -r requirements/test.txt, edx-django-release-util
+requests-oauthlib==1.3.0
+    # via -r requirements/test.txt, social-auth-core
+requests==2.24.0
+    # via -r requirements/docs.txt, -r requirements/test.txt, coreapi, requests-oauthlib, social-auth-core, sphinx
+ruamel.yaml.clib==0.2.2
+    # via -r requirements/test.txt, ruamel.yaml
+ruamel.yaml==0.16.12
+    # via -r requirements/test.txt, drf-yasg
+six==1.15.0
+    # via -r requirements/docs.txt, -r requirements/test.txt, astroid, cryptography, django-dynamic-fixture, edx-auth-backends, edx-django-release-util, edx-lint, edx-sphinx-theme, packaging, python-dateutil, social-auth-app-django, social-auth-core, sphinx
+snowballstemmer==2.0.0
+    # via -r requirements/docs.txt, sphinx
+social-auth-app-django==4.0.0
+    # via -r requirements/test.txt, edx-auth-backends
+social-auth-core==3.3.3
+    # via -r requirements/test.txt, edx-auth-backends, social-auth-app-django
+sphinx==1.6.7
+    # via -r requirements/docs.txt, edx-sphinx-theme
+sphinxcontrib-serializinghtml==1.1.4
+    # via -r requirements/docs.txt, sphinxcontrib-websupport
+sphinxcontrib-websupport==1.2.4
+    # via -r requirements/docs.txt, sphinx
+sqlparse==0.4.1
+    # via -r requirements/test.txt, django, django-debug-toolbar
+text-unidecode==1.3
+    # via -r requirements/test.txt, faker
+toml==0.10.2
+    # via -r requirements/test.txt, pytest
+typed-ast==1.4.1
+    # via -r requirements/test.txt, mypy
+typing-extensions==3.7.4.3
+    # via -r requirements/test.txt, mypy
+uritemplate==3.0.1
+    # via -r requirements/test.txt, coreapi, drf-yasg
+urllib3==1.25.11
+    # via -r requirements/docs.txt, -r requirements/test.txt, requests
+wrapt==1.11.2
+    # via -r requirements/test.txt, astroid
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,8 +4,10 @@
 #
 #    make upgrade
 #
-click==7.1.2              # via pip-tools
-pip-tools==5.5.0          # via -c requirements/constraints.txt, -r requirements/pip-tools.in
+click==7.1.2
+    # via pip-tools
+pip-tools==5.5.0
+    # via -c requirements/constraints.txt, -r requirements/pip-tools.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,10 +4,12 @@
 #
 #    make upgrade
 #
-click==7.1.2
+click==8.0.1
     # via pip-tools
 pip-tools==5.5.0
-    # via -c requirements/constraints.txt, -r requirements/pip-tools.in
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/pip-tools.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,121 +4,228 @@
 #
 #    make upgrade
 #
-attrs==18.2.0
-    # via -c requirements/constraints.txt, -r requirements/base.txt
-boto3==1.16.14
-    # via -c requirements/constraints.txt, -r requirements/production.in
-botocore==1.19.14
-    # via boto3, s3transfer
-certifi==2020.11.8
-    # via -r requirements/base.txt, requests
-cffi==1.14.3
-    # via -r requirements/base.txt, cryptography
-chardet==3.0.4
-    # via -r requirements/base.txt, requests
-coreapi==2.3.3
-    # via -r requirements/base.txt, drf-yasg
-coreschema==0.0.4
-    # via -r requirements/base.txt, coreapi, drf-yasg
-cryptography==3.2.1
-    # via -r requirements/base.txt, social-auth-core
-defusedxml==0.6.0
-    # via -r requirements/base.txt, python3-openid, social-auth-core
-django-cors-headers==2.2.1
-    # via -c requirements/constraints.txt, -r requirements/base.txt
-django-environ==0.4.5
-    # via -c requirements/constraints.txt, -r requirements/base.txt
-django-filter==2.1.0
-    # via -c requirements/constraints.txt, -r requirements/base.txt
-django-storages==1.10.1
-    # via -r requirements/production.in
-django-waffle==2.0.0
+attrs==21.2.0
     # via -r requirements/base.txt
-django==2.2.17
-    # via -c requirements/constraints.txt, -r requirements/base.txt, django-filter, django-storages, djangorestframework, drf-nested-routers, drf-yasg, edx-api-doc-tools, edx-auth-backends, edx-django-release-util
+boto3==1.17.78
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/production.in
+botocore==1.20.78
+    # via
+    #   boto3
+    #   s3transfer
+certifi==2020.12.5
+    # via
+    #   -r requirements/base.txt
+    #   requests
+cffi==1.14.5
+    # via
+    #   -r requirements/base.txt
+    #   cryptography
+chardet==4.0.0
+    # via
+    #   -r requirements/base.txt
+    #   requests
+coreapi==2.3.3
+    # via
+    #   -r requirements/base.txt
+    #   drf-yasg
+coreschema==0.0.4
+    # via
+    #   -r requirements/base.txt
+    #   coreapi
+    #   drf-yasg
+cryptography==3.3.2
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   social-auth-core
+defusedxml==0.7.1
+    # via
+    #   -r requirements/base.txt
+    #   python3-openid
+    #   social-auth-core
+django-cors-headers==2.2.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+django-environ==0.4.5
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+django-filter==2.1.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+django-storages==1.11.1
+    # via -r requirements/production.in
+django-waffle==2.2.0
+    # via -r requirements/base.txt
+django==2.2.23
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   django-filter
+    #   django-storages
+    #   djangorestframework
+    #   drf-nested-routers
+    #   drf-yasg
+    #   edx-api-doc-tools
+    #   edx-auth-backends
+    #   edx-django-release-util
 djangorestframework-expander==0.2.3
     # via -r requirements/base.txt
-djangorestframework==3.12.2
-    # via -r requirements/base.txt, djangorestframework-expander, drf-nested-routers, drf-yasg, edx-api-doc-tools
+djangorestframework==3.12.4
+    # via
+    #   -r requirements/base.txt
+    #   djangorestframework-expander
+    #   drf-nested-routers
+    #   drf-yasg
+    #   edx-api-doc-tools
 git+https://github.com/alanjds/drf-nested-routers.git@8686392f91b114e01f3781807dea60e9a80d3e07#egg=drf-nested-routers==0.91
     # via -r requirements/base.txt
 drf-yasg==1.20.0
-    # via -r requirements/base.txt, edx-api-doc-tools
+    # via
+    #   -r requirements/base.txt
+    #   edx-api-doc-tools
 edx-api-doc-tools==1.4.0
     # via -r requirements/base.txt
-edx-auth-backends==3.1.0
+edx-auth-backends==3.3.3
     # via -r requirements/base.txt
-edx-django-release-util==0.4.4
+edx-django-release-util==1.0.0
     # via -r requirements/base.txt
-gevent==20.9.0
+gevent==21.1.2
     # via -r requirements/production.in
-greenlet==0.4.17
+greenlet==1.1.0
     # via gevent
-gunicorn==20.0.4
+gunicorn==20.1.0
     # via -r requirements/production.in
 idna==2.10
-    # via -r requirements/base.txt, requests
+    # via
+    #   -r requirements/base.txt
+    #   requests
 inflection==0.5.1
-    # via -r requirements/base.txt, drf-yasg
+    # via
+    #   -r requirements/base.txt
+    #   drf-yasg
 itypes==1.2.0
-    # via -r requirements/base.txt, coreapi
-jinja2==2.11.2
-    # via -r requirements/base.txt, coreschema
+    # via
+    #   -r requirements/base.txt
+    #   coreapi
+jinja2==3.0.1
+    # via
+    #   -r requirements/base.txt
+    #   coreschema
 jmespath==0.10.0
-    # via boto3, botocore
-markupsafe==1.1.1
-    # via -r requirements/base.txt, jinja2
+    # via
+    #   boto3
+    #   botocore
+markupsafe==2.0.1
+    # via
+    #   -r requirements/base.txt
+    #   jinja2
 mysqlclient==1.3.14
-    # via -c requirements/constraints.txt, -r requirements/base.txt
-newrelic==5.22.1.152
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+newrelic==6.2.0.156
     # via -r requirements/production.in
 oauthlib==3.1.0
-    # via -r requirements/base.txt, requests-oauthlib, social-auth-core
-packaging==20.4
-    # via -r requirements/base.txt, drf-yasg
+    # via
+    #   -r requirements/base.txt
+    #   requests-oauthlib
+    #   social-auth-core
+packaging==20.9
+    # via
+    #   -r requirements/base.txt
+    #   drf-yasg
 pyblake2==1.1.2
     # via -r requirements/base.txt
 pycparser==2.20
-    # via -r requirements/base.txt, cffi
-pyjwt==1.7.1
-    # via -r requirements/base.txt, edx-auth-backends, social-auth-core
+    # via
+    #   -r requirements/base.txt
+    #   cffi
+pyjwt==2.1.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-auth-backends
+    #   social-auth-core
 pyparsing==2.4.7
-    # via -r requirements/base.txt, packaging
+    # via
+    #   -r requirements/base.txt
+    #   packaging
 python-dateutil==2.8.1
     # via botocore
 python-memcached==1.59
     # via -r requirements/production.in
 python3-openid==3.2.0
-    # via -r requirements/base.txt, social-auth-core
-pytz==2020.4
-    # via -r requirements/base.txt, django
-pyyaml==5.3.1
-    # via -r requirements/base.txt, -r requirements/production.in, edx-django-release-util
+    # via
+    #   -r requirements/base.txt
+    #   social-auth-core
+pytz==2021.1
+    # via
+    #   -r requirements/base.txt
+    #   django
+pyyaml==5.4.1
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/production.in
+    #   edx-django-release-util
 requests-oauthlib==1.3.0
-    # via -r requirements/base.txt, social-auth-core
-requests==2.24.0
-    # via -r requirements/base.txt, coreapi, requests-oauthlib, social-auth-core
+    # via
+    #   -r requirements/base.txt
+    #   social-auth-core
+requests==2.25.1
+    # via
+    #   -r requirements/base.txt
+    #   coreapi
+    #   requests-oauthlib
+    #   social-auth-core
 ruamel.yaml.clib==0.2.2
-    # via -r requirements/base.txt, ruamel.yaml
-ruamel.yaml==0.16.12
-    # via -r requirements/base.txt, drf-yasg
-s3transfer==0.3.3
+    # via
+    #   -r requirements/base.txt
+    #   ruamel.yaml
+ruamel.yaml==0.17.4
+    # via
+    #   -r requirements/base.txt
+    #   drf-yasg
+s3transfer==0.4.2
     # via boto3
-six==1.15.0
-    # via -r requirements/base.txt, cryptography, edx-auth-backends, edx-django-release-util, packaging, python-dateutil, python-memcached, social-auth-app-django, social-auth-core
+six==1.16.0
+    # via
+    #   -r requirements/base.txt
+    #   cryptography
+    #   edx-auth-backends
+    #   edx-django-release-util
+    #   python-dateutil
+    #   python-memcached
+    #   social-auth-app-django
 social-auth-app-django==4.0.0
-    # via -r requirements/base.txt, edx-auth-backends
-social-auth-core==3.3.3
-    # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
+    # via
+    #   -r requirements/base.txt
+    #   edx-auth-backends
+social-auth-core==4.1.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-auth-backends
+    #   social-auth-app-django
 sqlparse==0.4.1
-    # via -r requirements/base.txt, django
+    # via
+    #   -r requirements/base.txt
+    #   django
 uritemplate==3.0.1
-    # via -r requirements/base.txt, coreapi, drf-yasg
-urllib3==1.25.11
-    # via -r requirements/base.txt, botocore, requests
+    # via
+    #   -r requirements/base.txt
+    #   coreapi
+    #   drf-yasg
+urllib3==1.26.4
+    # via
+    #   -r requirements/base.txt
+    #   botocore
+    #   requests
 zope.event==4.5.0
     # via gevent
-zope.interface==5.2.0
+zope.interface==5.4.0
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,64 +4,122 @@
 #
 #    make upgrade
 #
-attrs==18.2.0             # via -c requirements/constraints.txt, -r requirements/base.txt
-boto3==1.16.14            # via -c requirements/constraints.txt, -r requirements/production.in
-botocore==1.19.14         # via boto3, s3transfer
-certifi==2020.11.8        # via -r requirements/base.txt, requests
-cffi==1.14.3              # via -r requirements/base.txt, cryptography
-chardet==3.0.4            # via -r requirements/base.txt, requests
-coreapi==2.3.3            # via -r requirements/base.txt, drf-yasg
-coreschema==0.0.4         # via -r requirements/base.txt, coreapi, drf-yasg
-cryptography==3.2.1       # via -r requirements/base.txt, social-auth-core
-defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core
-django-cors-headers==2.2.1  # via -c requirements/constraints.txt, -r requirements/base.txt
-django-environ==0.4.5     # via -c requirements/constraints.txt, -r requirements/base.txt
-django-filter==2.1.0      # via -c requirements/constraints.txt, -r requirements/base.txt
-django-storages==1.10.1   # via -r requirements/production.in
-django-waffle==2.0.0      # via -r requirements/base.txt
-django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.txt, django-filter, django-storages, djangorestframework, drf-nested-routers, drf-yasg, edx-api-doc-tools, edx-auth-backends, edx-django-release-util
-djangorestframework-expander==0.2.3  # via -r requirements/base.txt
-djangorestframework==3.12.2  # via -r requirements/base.txt, djangorestframework-expander, drf-nested-routers, drf-yasg, edx-api-doc-tools
-git+https://github.com/alanjds/drf-nested-routers.git@8686392f91b114e01f3781807dea60e9a80d3e07#egg=drf-nested-routers==0.91  # via -r requirements/base.txt
-drf-yasg==1.20.0          # via -r requirements/base.txt, edx-api-doc-tools
-edx-api-doc-tools==1.4.0  # via -r requirements/base.txt
-edx-auth-backends==3.1.0  # via -r requirements/base.txt
-edx-django-release-util==0.4.4  # via -r requirements/base.txt
-gevent==20.9.0            # via -r requirements/production.in
-greenlet==0.4.17          # via gevent
-gunicorn==20.0.4          # via -r requirements/production.in
-idna==2.10                # via -r requirements/base.txt, requests
-inflection==0.5.1         # via -r requirements/base.txt, drf-yasg
-itypes==1.2.0             # via -r requirements/base.txt, coreapi
-jinja2==2.11.2            # via -r requirements/base.txt, coreschema
-jmespath==0.10.0          # via boto3, botocore
-markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
-mysqlclient==1.3.14       # via -c requirements/constraints.txt, -r requirements/base.txt
-newrelic==5.22.1.152      # via -r requirements/production.in
-oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
-packaging==20.4           # via -r requirements/base.txt, drf-yasg
-pyblake2==1.1.2           # via -r requirements/base.txt
-pycparser==2.20           # via -r requirements/base.txt, cffi
-pyjwt==1.7.1              # via -r requirements/base.txt, edx-auth-backends, social-auth-core
-pyparsing==2.4.7          # via -r requirements/base.txt, packaging
-python-dateutil==2.8.1    # via botocore
-python-memcached==1.59    # via -r requirements/production.in
-python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
-pytz==2020.4              # via -r requirements/base.txt, django
-pyyaml==5.3.1             # via -r requirements/base.txt, -r requirements/production.in, edx-django-release-util
-requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
-requests==2.24.0          # via -r requirements/base.txt, coreapi, requests-oauthlib, social-auth-core
-ruamel.yaml.clib==0.2.2   # via -r requirements/base.txt, ruamel.yaml
-ruamel.yaml==0.16.12      # via -r requirements/base.txt, drf-yasg
-s3transfer==0.3.3         # via boto3
-six==1.15.0               # via -r requirements/base.txt, cryptography, edx-auth-backends, edx-django-release-util, packaging, python-dateutil, python-memcached, social-auth-app-django, social-auth-core
-social-auth-app-django==4.0.0  # via -r requirements/base.txt, edx-auth-backends
-social-auth-core==3.3.3   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
-sqlparse==0.4.1           # via -r requirements/base.txt, django
-uritemplate==3.0.1        # via -r requirements/base.txt, coreapi, drf-yasg
-urllib3==1.25.11          # via -r requirements/base.txt, botocore, requests
-zope.event==4.5.0         # via gevent
-zope.interface==5.2.0     # via gevent
+attrs==18.2.0
+    # via -c requirements/constraints.txt, -r requirements/base.txt
+boto3==1.16.14
+    # via -c requirements/constraints.txt, -r requirements/production.in
+botocore==1.19.14
+    # via boto3, s3transfer
+certifi==2020.11.8
+    # via -r requirements/base.txt, requests
+cffi==1.14.3
+    # via -r requirements/base.txt, cryptography
+chardet==3.0.4
+    # via -r requirements/base.txt, requests
+coreapi==2.3.3
+    # via -r requirements/base.txt, drf-yasg
+coreschema==0.0.4
+    # via -r requirements/base.txt, coreapi, drf-yasg
+cryptography==3.2.1
+    # via -r requirements/base.txt, social-auth-core
+defusedxml==0.6.0
+    # via -r requirements/base.txt, python3-openid, social-auth-core
+django-cors-headers==2.2.1
+    # via -c requirements/constraints.txt, -r requirements/base.txt
+django-environ==0.4.5
+    # via -c requirements/constraints.txt, -r requirements/base.txt
+django-filter==2.1.0
+    # via -c requirements/constraints.txt, -r requirements/base.txt
+django-storages==1.10.1
+    # via -r requirements/production.in
+django-waffle==2.0.0
+    # via -r requirements/base.txt
+django==2.2.17
+    # via -c requirements/constraints.txt, -r requirements/base.txt, django-filter, django-storages, djangorestframework, drf-nested-routers, drf-yasg, edx-api-doc-tools, edx-auth-backends, edx-django-release-util
+djangorestframework-expander==0.2.3
+    # via -r requirements/base.txt
+djangorestframework==3.12.2
+    # via -r requirements/base.txt, djangorestframework-expander, drf-nested-routers, drf-yasg, edx-api-doc-tools
+git+https://github.com/alanjds/drf-nested-routers.git@8686392f91b114e01f3781807dea60e9a80d3e07#egg=drf-nested-routers==0.91
+    # via -r requirements/base.txt
+drf-yasg==1.20.0
+    # via -r requirements/base.txt, edx-api-doc-tools
+edx-api-doc-tools==1.4.0
+    # via -r requirements/base.txt
+edx-auth-backends==3.1.0
+    # via -r requirements/base.txt
+edx-django-release-util==0.4.4
+    # via -r requirements/base.txt
+gevent==20.9.0
+    # via -r requirements/production.in
+greenlet==0.4.17
+    # via gevent
+gunicorn==20.0.4
+    # via -r requirements/production.in
+idna==2.10
+    # via -r requirements/base.txt, requests
+inflection==0.5.1
+    # via -r requirements/base.txt, drf-yasg
+itypes==1.2.0
+    # via -r requirements/base.txt, coreapi
+jinja2==2.11.2
+    # via -r requirements/base.txt, coreschema
+jmespath==0.10.0
+    # via boto3, botocore
+markupsafe==1.1.1
+    # via -r requirements/base.txt, jinja2
+mysqlclient==1.3.14
+    # via -c requirements/constraints.txt, -r requirements/base.txt
+newrelic==5.22.1.152
+    # via -r requirements/production.in
+oauthlib==3.1.0
+    # via -r requirements/base.txt, requests-oauthlib, social-auth-core
+packaging==20.4
+    # via -r requirements/base.txt, drf-yasg
+pyblake2==1.1.2
+    # via -r requirements/base.txt
+pycparser==2.20
+    # via -r requirements/base.txt, cffi
+pyjwt==1.7.1
+    # via -r requirements/base.txt, edx-auth-backends, social-auth-core
+pyparsing==2.4.7
+    # via -r requirements/base.txt, packaging
+python-dateutil==2.8.1
+    # via botocore
+python-memcached==1.59
+    # via -r requirements/production.in
+python3-openid==3.2.0
+    # via -r requirements/base.txt, social-auth-core
+pytz==2020.4
+    # via -r requirements/base.txt, django
+pyyaml==5.3.1
+    # via -r requirements/base.txt, -r requirements/production.in, edx-django-release-util
+requests-oauthlib==1.3.0
+    # via -r requirements/base.txt, social-auth-core
+requests==2.24.0
+    # via -r requirements/base.txt, coreapi, requests-oauthlib, social-auth-core
+ruamel.yaml.clib==0.2.2
+    # via -r requirements/base.txt, ruamel.yaml
+ruamel.yaml==0.16.12
+    # via -r requirements/base.txt, drf-yasg
+s3transfer==0.3.3
+    # via boto3
+six==1.15.0
+    # via -r requirements/base.txt, cryptography, edx-auth-backends, edx-django-release-util, packaging, python-dateutil, python-memcached, social-auth-app-django, social-auth-core
+social-auth-app-django==4.0.0
+    # via -r requirements/base.txt, edx-auth-backends
+social-auth-core==3.3.3
+    # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
+sqlparse==0.4.1
+    # via -r requirements/base.txt, django
+uritemplate==3.0.1
+    # via -r requirements/base.txt, coreapi, drf-yasg
+urllib3==1.25.11
+    # via -r requirements/base.txt, botocore, requests
+zope.event==4.5.0
+    # via gevent
+zope.interface==5.2.0
+    # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,163 +4,303 @@
 #
 #    make upgrade
 #
-astroid==2.3.3
-    # via -r requirements/test.in, pylint, pylint-celery
-attrs==18.2.0
-    # via -c requirements/constraints.txt, -r requirements/base.txt, pytest
-certifi==2020.11.8
-    # via -r requirements/base.txt, requests
-cffi==1.14.3
-    # via -r requirements/base.txt, cryptography
-chardet==3.0.4
-    # via -r requirements/base.txt, requests
+astroid==2.5.6
+    # via
+    #   -r requirements/test.in
+    #   pylint
+    #   pylint-celery
+attrs==21.2.0
+    # via
+    #   -r requirements/base.txt
+    #   pytest
+certifi==2020.12.5
+    # via
+    #   -r requirements/base.txt
+    #   requests
+cffi==1.14.5
+    # via
+    #   -r requirements/base.txt
+    #   cryptography
+chardet==4.0.0
+    # via
+    #   -r requirements/base.txt
+    #   diff-cover
+    #   requests
 click-log==0.3.2
     # via edx-lint
-click==7.1.2
-    # via click-log, edx-lint
+click==8.0.1
+    # via
+    #   click-log
+    #   code-annotations
+    #   edx-lint
+code-annotations==1.1.2
+    # via edx-lint
 coreapi==2.3.3
-    # via -r requirements/base.txt, drf-yasg
+    # via
+    #   -r requirements/base.txt
+    #   drf-yasg
 coreschema==0.0.4
-    # via -r requirements/base.txt, coreapi, drf-yasg
-coverage==5.3
-    # via -r requirements/test.in, pytest-cov
-cryptography==3.2.1
-    # via -r requirements/base.txt, social-auth-core
-ddt==1.4.1
+    # via
+    #   -r requirements/base.txt
+    #   coreapi
+    #   drf-yasg
+coverage[toml]==5.5
+    # via
+    #   -r requirements/test.in
+    #   pytest-cov
+cryptography==3.3.2
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   social-auth-core
+ddt==1.4.2
     # via -r requirements/test.in
-defusedxml==0.6.0
-    # via -r requirements/base.txt, python3-openid, social-auth-core
-diff-cover==4.0.1
+defusedxml==0.7.1
+    # via
+    #   -r requirements/base.txt
+    #   python3-openid
+    #   social-auth-core
+diff-cover==5.1.1
     # via -r requirements/test.in
 django-cors-headers==2.2.1
-    # via -c requirements/constraints.txt, -r requirements/base.txt
-django-dynamic-fixture==3.1.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+django-dynamic-fixture==3.1.1
     # via -r requirements/test.in
 django-environ==0.4.5
-    # via -c requirements/constraints.txt, -r requirements/base.txt
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
 django-filter==2.1.0
-    # via -c requirements/constraints.txt, -r requirements/base.txt
-django-waffle==2.0.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+django-waffle==2.2.0
     # via -r requirements/base.txt
-django==2.2.17
-    # via -c requirements/constraints.txt, -r requirements/base.txt, django-filter, djangorestframework, drf-nested-routers, drf-yasg, edx-api-doc-tools, edx-auth-backends, edx-django-release-util
+django==2.2.23
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   django-filter
+    #   djangorestframework
+    #   drf-nested-routers
+    #   drf-yasg
+    #   edx-api-doc-tools
+    #   edx-auth-backends
+    #   edx-django-release-util
+    #   edx-lint
 djangorestframework-expander==0.2.3
     # via -r requirements/base.txt
-djangorestframework==3.12.2
-    # via -r requirements/base.txt, djangorestframework-expander, drf-nested-routers, drf-yasg, edx-api-doc-tools
+djangorestframework==3.12.4
+    # via
+    #   -r requirements/base.txt
+    #   djangorestframework-expander
+    #   drf-nested-routers
+    #   drf-yasg
+    #   edx-api-doc-tools
 git+https://github.com/alanjds/drf-nested-routers.git@8686392f91b114e01f3781807dea60e9a80d3e07#egg=drf-nested-routers==0.91
     # via -r requirements/base.txt
 drf-yasg==1.20.0
-    # via -r requirements/base.txt, edx-api-doc-tools
+    # via
+    #   -r requirements/base.txt
+    #   edx-api-doc-tools
 edx-api-doc-tools==1.4.0
     # via -r requirements/base.txt
-edx-auth-backends==3.1.0
+edx-auth-backends==3.3.3
     # via -r requirements/base.txt
-edx-django-release-util==0.4.4
+edx-django-release-util==1.0.0
     # via -r requirements/base.txt
-edx-lint==1.5.2
+edx-lint==5.0.0
     # via -r requirements/test.in
-factory-boy==2.12.0
-    # via -c requirements/constraints.txt, -r requirements/test.in
-faker==4.14.2
+factory-boy==3.2.0
+    # via -r requirements/test.in
+faker==8.2.1
     # via factory-boy
 idna==2.10
-    # via -r requirements/base.txt, requests
-inflect==4.1.0
+    # via
+    #   -r requirements/base.txt
+    #   requests
+inflect==5.3.0
     # via jinja2-pluralize
 inflection==0.5.1
-    # via -r requirements/base.txt, drf-yasg
+    # via
+    #   -r requirements/base.txt
+    #   drf-yasg
 iniconfig==1.1.1
     # via pytest
-isort==4.3.21
+isort==5.8.0
     # via pylint
 itypes==1.2.0
-    # via -r requirements/base.txt, coreapi
+    # via
+    #   -r requirements/base.txt
+    #   coreapi
 jinja2-pluralize==0.3.0
     # via diff-cover
-jinja2==2.11.2
-    # via -r requirements/base.txt, coreschema, diff-cover, jinja2-pluralize
-lazy-object-proxy==1.4.3
+jinja2==3.0.1
+    # via
+    #   -r requirements/base.txt
+    #   code-annotations
+    #   coreschema
+    #   diff-cover
+    #   jinja2-pluralize
+lazy-object-proxy==1.6.0
     # via astroid
-markupsafe==1.1.1
-    # via -r requirements/base.txt, jinja2
+markupsafe==2.0.1
+    # via
+    #   -r requirements/base.txt
+    #   jinja2
 mccabe==0.6.1
     # via pylint
 mypy-extensions==0.4.3
     # via mypy
-mypy==0.790
+mypy==0.812
     # via -r requirements/test.in
 mysqlclient==1.3.14
-    # via -c requirements/constraints.txt, -r requirements/base.txt
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
 oauthlib==3.1.0
-    # via -r requirements/base.txt, requests-oauthlib, social-auth-core
-packaging==20.4
-    # via -r requirements/base.txt, drf-yasg, pytest
+    # via
+    #   -r requirements/base.txt
+    #   requests-oauthlib
+    #   social-auth-core
+packaging==20.9
+    # via
+    #   -r requirements/base.txt
+    #   drf-yasg
+    #   pytest
+pbr==5.6.0
+    # via stevedore
 pluggy==0.13.1
-    # via diff-cover, pytest
-py==1.9.0
+    # via
+    #   diff-cover
+    #   pytest
+py==1.10.0
     # via pytest
 pyblake2==1.1.2
     # via -r requirements/base.txt
-pycodestyle==2.6.0
+pycodestyle==2.7.0
     # via -r requirements/test.in
 pycparser==2.20
-    # via -r requirements/base.txt, cffi
-pygments==2.7.2
+    # via
+    #   -r requirements/base.txt
+    #   cffi
+pygments==2.9.0
     # via diff-cover
-pyjwt==1.7.1
-    # via -r requirements/base.txt, edx-auth-backends, social-auth-core
+pyjwt==2.1.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-auth-backends
+    #   social-auth-core
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.0.11
+pylint-django==2.4.4
     # via edx-lint
 pylint-plugin-utils==0.6
-    # via pylint-celery, pylint-django
-pylint==2.4.4
-    # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+    # via
+    #   pylint-celery
+    #   pylint-django
+pylint==2.8.2
+    # via
+    #   edx-lint
+    #   pylint-celery
+    #   pylint-django
+    #   pylint-plugin-utils
 pyparsing==2.4.7
-    # via -r requirements/base.txt, packaging
-pytest-cov==2.10.1
+    # via
+    #   -r requirements/base.txt
+    #   packaging
+pytest-cov==2.12.0
     # via -r requirements/test.in
-pytest-django==4.1.0
+pytest-django==4.3.0
     # via -r requirements/test.in
-pytest==6.1.2
-    # via -r requirements/test.in, pytest-cov, pytest-django
+pytest==6.2.4
+    # via
+    #   -r requirements/test.in
+    #   pytest-cov
+    #   pytest-django
 python-dateutil==2.8.1
     # via faker
+python-slugify==5.0.2
+    # via code-annotations
 python3-openid==3.2.0
-    # via -r requirements/base.txt, social-auth-core
-pytz==2020.4
-    # via -r requirements/base.txt, django
-pyyaml==5.3.1
-    # via -r requirements/base.txt, edx-django-release-util
+    # via
+    #   -r requirements/base.txt
+    #   social-auth-core
+pytz==2021.1
+    # via
+    #   -r requirements/base.txt
+    #   django
+pyyaml==5.4.1
+    # via
+    #   -r requirements/base.txt
+    #   code-annotations
+    #   edx-django-release-util
 requests-oauthlib==1.3.0
-    # via -r requirements/base.txt, social-auth-core
-requests==2.24.0
-    # via -r requirements/base.txt, coreapi, requests-oauthlib, social-auth-core
+    # via
+    #   -r requirements/base.txt
+    #   social-auth-core
+requests==2.25.1
+    # via
+    #   -r requirements/base.txt
+    #   coreapi
+    #   requests-oauthlib
+    #   social-auth-core
 ruamel.yaml.clib==0.2.2
-    # via -r requirements/base.txt, ruamel.yaml
-ruamel.yaml==0.16.12
-    # via -r requirements/base.txt, drf-yasg
-six==1.15.0
-    # via -r requirements/base.txt, astroid, cryptography, django-dynamic-fixture, edx-auth-backends, edx-django-release-util, edx-lint, packaging, python-dateutil, social-auth-app-django, social-auth-core
+    # via
+    #   -r requirements/base.txt
+    #   ruamel.yaml
+ruamel.yaml==0.17.4
+    # via
+    #   -r requirements/base.txt
+    #   drf-yasg
+six==1.16.0
+    # via
+    #   -r requirements/base.txt
+    #   cryptography
+    #   django-dynamic-fixture
+    #   edx-auth-backends
+    #   edx-django-release-util
+    #   edx-lint
+    #   python-dateutil
+    #   social-auth-app-django
 social-auth-app-django==4.0.0
-    # via -r requirements/base.txt, edx-auth-backends
-social-auth-core==3.3.3
-    # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
+    # via
+    #   -r requirements/base.txt
+    #   edx-auth-backends
+social-auth-core==4.1.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-auth-backends
+    #   social-auth-app-django
 sqlparse==0.4.1
-    # via -r requirements/base.txt, django
+    # via
+    #   -r requirements/base.txt
+    #   django
+stevedore==3.3.0
+    # via code-annotations
 text-unidecode==1.3
-    # via faker
+    # via
+    #   faker
+    #   python-slugify
 toml==0.10.2
-    # via pytest
-typed-ast==1.4.1
+    # via
+    #   coverage
+    #   pylint
+    #   pytest
+typed-ast==1.4.3
     # via mypy
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via mypy
 uritemplate==3.0.1
-    # via -r requirements/base.txt, coreapi, drf-yasg
-urllib3==1.25.11
-    # via -r requirements/base.txt, requests
-wrapt==1.11.2
+    # via
+    #   -r requirements/base.txt
+    #   coreapi
+    #   drf-yasg
+urllib3==1.26.4
+    # via
+    #   -r requirements/base.txt
+    #   requests
+wrapt==1.12.1
     # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,83 +4,163 @@
 #
 #    make upgrade
 #
-astroid==2.3.3            # via -r requirements/test.in, pylint, pylint-celery
-attrs==18.2.0             # via -c requirements/constraints.txt, -r requirements/base.txt, pytest
-certifi==2020.11.8        # via -r requirements/base.txt, requests
-cffi==1.14.3              # via -r requirements/base.txt, cryptography
-chardet==3.0.4            # via -r requirements/base.txt, requests
-click-log==0.3.2          # via edx-lint
-click==7.1.2              # via click-log, edx-lint
-coreapi==2.3.3            # via -r requirements/base.txt, drf-yasg
-coreschema==0.0.4         # via -r requirements/base.txt, coreapi, drf-yasg
-coverage==5.3             # via -r requirements/test.in, pytest-cov
-cryptography==3.2.1       # via -r requirements/base.txt, social-auth-core
-ddt==1.4.1                # via -r requirements/test.in
-defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core
-diff-cover==4.0.1         # via -r requirements/test.in
-django-cors-headers==2.2.1  # via -c requirements/constraints.txt, -r requirements/base.txt
-django-dynamic-fixture==3.1.0  # via -r requirements/test.in
-django-environ==0.4.5     # via -c requirements/constraints.txt, -r requirements/base.txt
-django-filter==2.1.0      # via -c requirements/constraints.txt, -r requirements/base.txt
-django-waffle==2.0.0      # via -r requirements/base.txt
-django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.txt, django-filter, djangorestframework, drf-nested-routers, drf-yasg, edx-api-doc-tools, edx-auth-backends, edx-django-release-util
-djangorestframework-expander==0.2.3  # via -r requirements/base.txt
-djangorestframework==3.12.2  # via -r requirements/base.txt, djangorestframework-expander, drf-nested-routers, drf-yasg, edx-api-doc-tools
-git+https://github.com/alanjds/drf-nested-routers.git@8686392f91b114e01f3781807dea60e9a80d3e07#egg=drf-nested-routers==0.91  # via -r requirements/base.txt
-drf-yasg==1.20.0          # via -r requirements/base.txt, edx-api-doc-tools
-edx-api-doc-tools==1.4.0  # via -r requirements/base.txt
-edx-auth-backends==3.1.0  # via -r requirements/base.txt
-edx-django-release-util==0.4.4  # via -r requirements/base.txt
-edx-lint==1.5.2           # via -r requirements/test.in
-factory-boy==2.12.0       # via -c requirements/constraints.txt, -r requirements/test.in
-faker==4.14.2             # via factory-boy
-idna==2.10                # via -r requirements/base.txt, requests
-inflect==4.1.0            # via jinja2-pluralize
-inflection==0.5.1         # via -r requirements/base.txt, drf-yasg
-iniconfig==1.1.1          # via pytest
-isort==4.3.21             # via pylint
-itypes==1.2.0             # via -r requirements/base.txt, coreapi
-jinja2-pluralize==0.3.0   # via diff-cover
-jinja2==2.11.2            # via -r requirements/base.txt, coreschema, diff-cover, jinja2-pluralize
-lazy-object-proxy==1.4.3  # via astroid
-markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
-mccabe==0.6.1             # via pylint
-mypy-extensions==0.4.3    # via mypy
-mypy==0.790               # via -r requirements/test.in
-mysqlclient==1.3.14       # via -c requirements/constraints.txt, -r requirements/base.txt
-oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
-packaging==20.4           # via -r requirements/base.txt, drf-yasg, pytest
-pluggy==0.13.1            # via diff-cover, pytest
-py==1.9.0                 # via pytest
-pyblake2==1.1.2           # via -r requirements/base.txt
-pycodestyle==2.6.0        # via -r requirements/test.in
-pycparser==2.20           # via -r requirements/base.txt, cffi
-pygments==2.7.2           # via diff-cover
-pyjwt==1.7.1              # via -r requirements/base.txt, edx-auth-backends, social-auth-core
-pylint-celery==0.3        # via edx-lint
-pylint-django==2.0.11     # via edx-lint
-pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pyparsing==2.4.7          # via -r requirements/base.txt, packaging
-pytest-cov==2.10.1        # via -r requirements/test.in
-pytest-django==4.1.0      # via -r requirements/test.in
-pytest==6.1.2             # via -r requirements/test.in, pytest-cov, pytest-django
-python-dateutil==2.8.1    # via faker
-python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
-pytz==2020.4              # via -r requirements/base.txt, django
-pyyaml==5.3.1             # via -r requirements/base.txt, edx-django-release-util
-requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
-requests==2.24.0          # via -r requirements/base.txt, coreapi, requests-oauthlib, social-auth-core
-ruamel.yaml.clib==0.2.2   # via -r requirements/base.txt, ruamel.yaml
-ruamel.yaml==0.16.12      # via -r requirements/base.txt, drf-yasg
-six==1.15.0               # via -r requirements/base.txt, astroid, cryptography, django-dynamic-fixture, edx-auth-backends, edx-django-release-util, edx-lint, packaging, python-dateutil, social-auth-app-django, social-auth-core
-social-auth-app-django==4.0.0  # via -r requirements/base.txt, edx-auth-backends
-social-auth-core==3.3.3   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
-sqlparse==0.4.1           # via -r requirements/base.txt, django
-text-unidecode==1.3       # via faker
-toml==0.10.2              # via pytest
-typed-ast==1.4.1          # via mypy
-typing-extensions==3.7.4.3  # via mypy
-uritemplate==3.0.1        # via -r requirements/base.txt, coreapi, drf-yasg
-urllib3==1.25.11          # via -r requirements/base.txt, requests
-wrapt==1.11.2             # via astroid
+astroid==2.3.3
+    # via -r requirements/test.in, pylint, pylint-celery
+attrs==18.2.0
+    # via -c requirements/constraints.txt, -r requirements/base.txt, pytest
+certifi==2020.11.8
+    # via -r requirements/base.txt, requests
+cffi==1.14.3
+    # via -r requirements/base.txt, cryptography
+chardet==3.0.4
+    # via -r requirements/base.txt, requests
+click-log==0.3.2
+    # via edx-lint
+click==7.1.2
+    # via click-log, edx-lint
+coreapi==2.3.3
+    # via -r requirements/base.txt, drf-yasg
+coreschema==0.0.4
+    # via -r requirements/base.txt, coreapi, drf-yasg
+coverage==5.3
+    # via -r requirements/test.in, pytest-cov
+cryptography==3.2.1
+    # via -r requirements/base.txt, social-auth-core
+ddt==1.4.1
+    # via -r requirements/test.in
+defusedxml==0.6.0
+    # via -r requirements/base.txt, python3-openid, social-auth-core
+diff-cover==4.0.1
+    # via -r requirements/test.in
+django-cors-headers==2.2.1
+    # via -c requirements/constraints.txt, -r requirements/base.txt
+django-dynamic-fixture==3.1.0
+    # via -r requirements/test.in
+django-environ==0.4.5
+    # via -c requirements/constraints.txt, -r requirements/base.txt
+django-filter==2.1.0
+    # via -c requirements/constraints.txt, -r requirements/base.txt
+django-waffle==2.0.0
+    # via -r requirements/base.txt
+django==2.2.17
+    # via -c requirements/constraints.txt, -r requirements/base.txt, django-filter, djangorestframework, drf-nested-routers, drf-yasg, edx-api-doc-tools, edx-auth-backends, edx-django-release-util
+djangorestframework-expander==0.2.3
+    # via -r requirements/base.txt
+djangorestframework==3.12.2
+    # via -r requirements/base.txt, djangorestframework-expander, drf-nested-routers, drf-yasg, edx-api-doc-tools
+git+https://github.com/alanjds/drf-nested-routers.git@8686392f91b114e01f3781807dea60e9a80d3e07#egg=drf-nested-routers==0.91
+    # via -r requirements/base.txt
+drf-yasg==1.20.0
+    # via -r requirements/base.txt, edx-api-doc-tools
+edx-api-doc-tools==1.4.0
+    # via -r requirements/base.txt
+edx-auth-backends==3.1.0
+    # via -r requirements/base.txt
+edx-django-release-util==0.4.4
+    # via -r requirements/base.txt
+edx-lint==1.5.2
+    # via -r requirements/test.in
+factory-boy==2.12.0
+    # via -c requirements/constraints.txt, -r requirements/test.in
+faker==4.14.2
+    # via factory-boy
+idna==2.10
+    # via -r requirements/base.txt, requests
+inflect==4.1.0
+    # via jinja2-pluralize
+inflection==0.5.1
+    # via -r requirements/base.txt, drf-yasg
+iniconfig==1.1.1
+    # via pytest
+isort==4.3.21
+    # via pylint
+itypes==1.2.0
+    # via -r requirements/base.txt, coreapi
+jinja2-pluralize==0.3.0
+    # via diff-cover
+jinja2==2.11.2
+    # via -r requirements/base.txt, coreschema, diff-cover, jinja2-pluralize
+lazy-object-proxy==1.4.3
+    # via astroid
+markupsafe==1.1.1
+    # via -r requirements/base.txt, jinja2
+mccabe==0.6.1
+    # via pylint
+mypy-extensions==0.4.3
+    # via mypy
+mypy==0.790
+    # via -r requirements/test.in
+mysqlclient==1.3.14
+    # via -c requirements/constraints.txt, -r requirements/base.txt
+oauthlib==3.1.0
+    # via -r requirements/base.txt, requests-oauthlib, social-auth-core
+packaging==20.4
+    # via -r requirements/base.txt, drf-yasg, pytest
+pluggy==0.13.1
+    # via diff-cover, pytest
+py==1.9.0
+    # via pytest
+pyblake2==1.1.2
+    # via -r requirements/base.txt
+pycodestyle==2.6.0
+    # via -r requirements/test.in
+pycparser==2.20
+    # via -r requirements/base.txt, cffi
+pygments==2.7.2
+    # via diff-cover
+pyjwt==1.7.1
+    # via -r requirements/base.txt, edx-auth-backends, social-auth-core
+pylint-celery==0.3
+    # via edx-lint
+pylint-django==2.0.11
+    # via edx-lint
+pylint-plugin-utils==0.6
+    # via pylint-celery, pylint-django
+pylint==2.4.4
+    # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pyparsing==2.4.7
+    # via -r requirements/base.txt, packaging
+pytest-cov==2.10.1
+    # via -r requirements/test.in
+pytest-django==4.1.0
+    # via -r requirements/test.in
+pytest==6.1.2
+    # via -r requirements/test.in, pytest-cov, pytest-django
+python-dateutil==2.8.1
+    # via faker
+python3-openid==3.2.0
+    # via -r requirements/base.txt, social-auth-core
+pytz==2020.4
+    # via -r requirements/base.txt, django
+pyyaml==5.3.1
+    # via -r requirements/base.txt, edx-django-release-util
+requests-oauthlib==1.3.0
+    # via -r requirements/base.txt, social-auth-core
+requests==2.24.0
+    # via -r requirements/base.txt, coreapi, requests-oauthlib, social-auth-core
+ruamel.yaml.clib==0.2.2
+    # via -r requirements/base.txt, ruamel.yaml
+ruamel.yaml==0.16.12
+    # via -r requirements/base.txt, drf-yasg
+six==1.15.0
+    # via -r requirements/base.txt, astroid, cryptography, django-dynamic-fixture, edx-auth-backends, edx-django-release-util, edx-lint, packaging, python-dateutil, social-auth-app-django, social-auth-core
+social-auth-app-django==4.0.0
+    # via -r requirements/base.txt, edx-auth-backends
+social-auth-core==3.3.3
+    # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
+sqlparse==0.4.1
+    # via -r requirements/base.txt, django
+text-unidecode==1.3
+    # via faker
+toml==0.10.2
+    # via pytest
+typed-ast==1.4.1
+    # via mypy
+typing-extensions==3.7.4.3
+    # via mypy
+uritemplate==3.0.1
+    # via -r requirements/base.txt, coreapi, drf-yasg
+urllib3==1.25.11
+    # via -r requirements/base.txt, requests
+wrapt==1.11.2
+    # via astroid

--- a/tagstore/backends/django.py
+++ b/tagstore/backends/django.py
@@ -38,8 +38,8 @@ class DjangoTagstore(Tagstore):
             # Check the parent tag:
             try:
                 pt = TagModel.objects.get(taxonomy_id=taxonomy_uid, name=parent_tag)
-            except TagModel.DoesNotExist:
-                raise ValueError("Invalid parent tag.")
+            except TagModel.DoesNotExist as exc:
+                raise ValueError("Invalid parent tag.") from exc
             path = TagModel.make_path(taxonomy_uid, name, pt.path)
         else:
             path = TagModel.make_path(taxonomy_uid, name)

--- a/tagstore/models/tag.py
+++ b/tagstore/models/tag.py
@@ -4,7 +4,7 @@ Data models for tags
 from collections import namedtuple
 
 
-TagPrivate = namedtuple('Tag', ['taxonomy_uid', 'name'])
+TagPrivate = namedtuple('Tag', ['taxonomy_uid', 'name'])  # type: ignore
 
 
 class Tag(TagPrivate):


### PR DESCRIPTION
In this PR, we:
* modify requirements constraints to fix the requirements upgrade job,
* upgrade requirements pins, and
* fix the build issues resulting from the upgraded pins.

See individual commits for more detail.

I ran unit tests and quality checks locally. I plan to deploy Blockstore to production shortly after merging.

**Urgency: Moderate-low.** While not causing production issues, T&L gets alerted every week when the requirements job fails. Also, Blockstore goes months without being deployed, which isn't great (what if the pipeline stops working and we don't notice?). By getting the weekly upgrade cadence going again, we can keep version pins fresh and ensure we're deploying regularly.