### PR TITLE
BOM-2247 - Upgrade pip-tools

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -21,8 +21,6 @@ django-filter==2.1.0
 
 mysqlclient==1.3.14
 
-pip-tools<6.0
-
 # We want >=3.3.2 to fix a moderate-severity security issue
 # reported here: https://github.com/pyca/cryptography/issues/5615.
 # However, we want <3.4 because the usage of Rust in cryptography>=3.4

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -6,10 +6,12 @@
 #
 click==8.0.1
     # via pip-tools
-pip-tools==5.5.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/pip-tools.in
+pep517==0.10.0
+    # via pip-tools
+pip-tools==6.1.0
+    # via -r requirements/pip-tools.in
+toml==0.10.2
+    # via pep517
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip


### PR DESCRIPTION
Now that we are have pinned pip to version 20.3.4 in configuration, which is compatible with the latest version of pip-tools according to this compatibility chart
https://github.com/jazzband/pip-tools/#versions-and-compatibility

So in this PR, we are upgrading the latest pip-tools.

Relevant JIRA: https://openedx.atlassian.net/browse/BOM-2247