### PR TITLE
fix: fix SSO by constraining requirements using common_constraints

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -21,6 +21,7 @@ coreschema==0.0.4
 cryptography==3.3.2
     # via
     #   -c requirements/constraints.txt
+    #   pyjwt
     #   social-auth-core
 defusedxml==0.7.1
     # via
@@ -28,6 +29,7 @@ defusedxml==0.7.1
     #   social-auth-core
 django==2.2.24
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   django-filter
@@ -94,8 +96,9 @@ pyblake2==1.1.2
     # via -r requirements/base.in
 pycparser==2.20
     # via cffi
-pyjwt==2.1.0
+pyjwt[crypto]==1.7.1
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   edx-auth-backends
     #   social-auth-core
 pyparsing==2.4.7
@@ -125,10 +128,12 @@ six==1.16.0
     #   edx-auth-backends
     #   edx-django-release-util
     #   social-auth-app-django
+    #   social-auth-core
 social-auth-app-django==4.0.0
     # via edx-auth-backends
-social-auth-core==4.1.0
+social-auth-core==4.0.2
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   edx-auth-backends
     #   social-auth-app-django
 sqlparse==0.4.1

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,6 +8,9 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
+# This file contains all common constraints for edx-repos
+-c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+
 boto3<2.0
 
 # Not yet using Django 3.X. Using the 2.X LTS to mirror the LMS.

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -70,6 +70,7 @@ cryptography==3.3.2
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
+    #   pyjwt
     #   social-auth-core
 ddt==1.4.2
     # via -r requirements/test.txt
@@ -82,6 +83,7 @@ diff-cover==6.2.1
     # via -r requirements/test.txt
 django==2.2.24
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   django-debug-toolbar
@@ -248,8 +250,9 @@ pygments==2.9.0
     #   -r requirements/test.txt
     #   diff-cover
     #   sphinx
-pyjwt==2.1.0
+pyjwt[crypto]==1.7.1
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
     #   edx-auth-backends
     #   social-auth-core
@@ -341,6 +344,7 @@ six==1.16.0
     #   edx-sphinx-theme
     #   python-dateutil
     #   social-auth-app-django
+    #   social-auth-core
     #   sphinx
 snowballstemmer==2.1.0
     # via
@@ -350,8 +354,9 @@ social-auth-app-django==4.0.0
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends
-social-auth-core==4.1.0
+social-auth-core==4.0.2
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
     #   edx-auth-backends
     #   social-auth-app-django

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -39,6 +39,7 @@ cryptography==3.3.2
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
+    #   pyjwt
     #   social-auth-core
 defusedxml==0.7.1
     # via
@@ -47,6 +48,7 @@ defusedxml==0.7.1
     #   social-auth-core
 django==2.2.24
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   django-filter
@@ -145,8 +147,9 @@ pycparser==2.20
     # via
     #   -r requirements/base.txt
     #   cffi
-pyjwt==2.1.0
+pyjwt[crypto]==1.7.1
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
     #   edx-auth-backends
     #   social-auth-core
@@ -200,12 +203,14 @@ six==1.16.0
     #   python-dateutil
     #   python-memcached
     #   social-auth-app-django
+    #   social-auth-core
 social-auth-app-django==4.0.0
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
-social-auth-core==4.1.0
+social-auth-core==4.0.2
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
     #   edx-auth-backends
     #   social-auth-app-django

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -53,6 +53,7 @@ cryptography==3.3.2
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
+    #   pyjwt
     #   social-auth-core
 ddt==1.4.2
     # via -r requirements/test.in
@@ -65,6 +66,7 @@ diff-cover==6.2.1
     # via -r requirements/test.in
 django==2.2.24
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   django-filter
@@ -189,8 +191,9 @@ pycparser==2.20
     #   cffi
 pygments==2.9.0
     # via diff-cover
-pyjwt==2.1.0
+pyjwt[crypto]==1.7.1
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
     #   edx-auth-backends
     #   social-auth-core
@@ -266,12 +269,14 @@ six==1.16.0
     #   edx-lint
     #   python-dateutil
     #   social-auth-app-django
+    #   social-auth-core
 social-auth-app-django==4.0.0
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
-social-auth-core==4.1.0
+social-auth-core==4.0.2
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
     #   edx-auth-backends
     #   social-auth-app-django


### PR DESCRIPTION
## Description

Include [common_constraints](https://github.com/edx/edx-lint/blob/master/edx_lint/files/common_constraints.txt) file in Python requirements compiling process. The includes constraints to avoid versions of Python packages that are known to be problematic across Open edX repositories.

After running `make upgrade` again, social-auth-core and pyjwt and both downgraded. This should fix an issue in which the LMS->Blockstore SSO flow is failing to complete, preventing users from accessing the Blockstore Django admin panel.

## Supporting Information

https://openedx.atlassian.net/browse/TNL-8609 

## Testing instructions

Setup:
* Follow the [Blockstore devstack setup instructions](https://github.com/edx/blockstore#using-with-docker-devstack) if you haven't already.
* Start devstack LMS

Replicate bug:
* Check out blockstore master
* Start blockstore easyserver
* Navigate to blockstore login (https://localhost:18250/login)
* Log in via LMS as an admin (edx@example.com / edx)
* You should be redirected back to blockstore, but see an error that stops auth from completing:

![image](https://user-images.githubusercontent.com/3628148/128236889-83a26900-9c39-4480-9941-7387bee92cbe.png)

Confirm fix:
* Check out this branch of blockstore
* Kill blockstore easyserver and restart it
* Navigate to blockstore login (https://localhost:18250/login)
* (LMS may or may not ask you to log in again)
* Notice that you successfully authenticate into the blockstore Django admin panel:
![image](https://user-images.githubusercontent.com/3628148/128237370-30e7fdcd-da1a-4e16-853d-50bf038a7436.png)


