### PR TITLE
test: Adding test to check jwt encode and decode methods.

### DIFF
--- a/blockstore/apps/core/tests/test_jwt.py
+++ b/blockstore/apps/core/tests/test_jwt.py
@@ -1,0 +1,62 @@
+"""
+Tests for the JWT sanity check.
+Checking edx-drf-extensinos method.
+Checking jwt.encode and jwt.decode methods.
+"""
+from time import time
+from django.test import TestCase
+
+import jwt
+from auth_backends.tests.test_backends import EdXOAuth2Tests
+from django.contrib.auth import get_user_model
+from edx_rest_framework_extensions.auth.jwt.decoder import jwt_decode_handler  # pylint: disable=import-error
+from edx_rest_framework_extensions.auth.jwt.tests.utils import (    # pylint: disable=import-error
+    generate_jwt_token, generate_latest_version_payload
+)
+
+User = get_user_model()
+
+
+def get_jwt_payload():
+    """ Returns a JWT payload with the necessary claims to create a new user. """
+    email = 'gcostanza@gmail.com'
+    username = 'gcostanza'
+    payload = dict({'preferred_username': username, 'email': email})
+
+    return payload
+
+
+class Oauth2Tests(EdXOAuth2Tests):       # pylint: disable=test-inherits-tests
+    """Running EdXOAuth2Tests here."""
+
+
+class JWTDecodeHandlerTests(TestCase):
+    """ Tests for the `jwt_decode_handler` utility function. """
+
+    def test_success(self):
+        """
+        Confirms that the format of the valid response from the token decoder matches the payload
+        """
+        user = User.objects.create(username='test-service-user')
+        payload = generate_latest_version_payload(user)
+        jwt_tk = generate_jwt_token(payload)
+        self.assertDictEqual(jwt_decode_handler(jwt_tk), payload)
+
+    def test_encode_decode(self):
+        """
+        This test checking directly jwt.encode and jwt.decode methods.
+        """
+        now = int(time())
+        payload = {
+            "iss": 'test-issue',
+            "aud": 'test-audience',
+            "exp": now + 10,
+            "iat": now,
+            "username": 'staff',
+            "email": 'staff@example.com',
+        }
+        secret = 'test-secret'
+        jwt_message = jwt.encode(payload, secret)
+        decoded_payload = jwt.decode(jwt_message, secret, verify=False)
+
+        assert payload == decoded_payload

--- a/blockstore/settings/test.py
+++ b/blockstore/settings/test.py
@@ -29,3 +29,41 @@ DATABASES = {
 
 # Give each test run a separate storage space.
 MEDIA_ROOT = create_timestamped_path("test_storage")
+
+
+# settings require for edx-drf-extensions tests.
+JWT_AUTH = {
+
+    'JWT_AUDIENCE': 'test-aud',
+
+    'JWT_DECODE_HANDLER': 'edx_rest_framework_extensions.auth.jwt.decoder.jwt_decode_handler',
+
+    'JWT_ISSUER': 'test-iss',
+
+    'JWT_LEEWAY': 1,
+
+    'JWT_SECRET_KEY': 'test-key',
+
+    'JWT_SUPPORTED_VERSION': '1.0.0',
+
+    'JWT_VERIFY_AUDIENCE': False,
+
+    'JWT_VERIFY_EXPIRATION': True,
+
+    'JWT_AUTH_HEADER_PREFIX': 'JWT',
+    # JWT_ISSUERS enables token decoding for multiple issuers (Note: This is not a native DRF-JWT field)
+    # We use it to allow different values for the 'ISSUER' field, but keep the same SECRET_KEY and
+    # AUDIENCE values across all issuers.
+    'JWT_ISSUERS': [
+        {
+            'ISSUER': 'test-issuer-1',
+            'SECRET_KEY': 'test-secret-key',
+            'AUDIENCE': 'test-audience',
+        },
+        {
+            'ISSUER': 'test-issuer-2',
+            'SECRET_KEY': 'test-secret-key',
+            'AUDIENCE': 'test-audience',
+        }
+    ],
+}

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -16,3 +16,4 @@ edx-django-release-util
 mysqlclient
 pytz
 sqlparse
+social-auth-app-django<5.0.0  # 5th aug release giving version conflict in upgrade job

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -130,7 +130,9 @@ six==1.16.0
     #   social-auth-app-django
     #   social-auth-core
 social-auth-app-django==4.0.0
-    # via edx-auth-backends
+    # via
+    #   -r requirements/base.in
+    #   edx-auth-backends
 social-auth-core==4.0.2
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -8,6 +8,10 @@ alabaster==0.7.12
     # via
     #   -r requirements/docs.txt
     #   sphinx
+argparse==1.4.0
+    # via
+    #   -r requirements/test.txt
+    #   unittest2
 astroid==2.6.6
     # via
     #   -r requirements/test.txt
@@ -148,6 +152,8 @@ faker==8.11.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
+httpretty==1.1.3
+    # via -r requirements/test.txt
 idna==3.2
     # via
     #   -r requirements/docs.txt
@@ -194,6 +200,10 @@ lazy-object-proxy==1.6.0
     # via
     #   -r requirements/test.txt
     #   astroid
+linecache2==1.0.0
+    # via
+    #   -r requirements/test.txt
+    #   traceback2
 markupsafe==2.0.1
     # via
     #   -r requirements/docs.txt
@@ -346,6 +356,7 @@ six==1.16.0
     #   social-auth-app-django
     #   social-auth-core
     #   sphinx
+    #   unittest2
 snowballstemmer==2.1.0
     # via
     #   -r requirements/docs.txt
@@ -393,10 +404,16 @@ toml==0.10.2
     #   pylint
     #   pytest
     #   pytest-cov
+traceback2==1.4.0
+    # via
+    #   -r requirements/test.txt
+    #   unittest2
 typing-extensions==3.10.0.0
     # via
     #   -r requirements/test.txt
     #   mypy
+unittest2==1.1.0
+    # via -r requirements/test.txt
 uritemplate==3.0.1
     # via
     #   -r requirements/test.txt

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -10,7 +10,7 @@ pep517==0.11.0
     # via pip-tools
 pip-tools==6.2.0
     # via -r requirements/pip-tools.in
-tomli==1.2.0
+tomli==1.2.1
     # via pep517
 wheel==0.36.2
     # via pip-tools

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -6,11 +6,11 @@
 #
 attrs==21.2.0
     # via -r requirements/base.txt
-boto3==1.18.13
+boto3==1.18.15
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/production.in
-botocore==1.21.13
+botocore==1.21.15
     # via
     #   boto3
     #   s3transfer
@@ -96,7 +96,7 @@ edx-auth-backends==3.4.0
     # via -r requirements/base.txt
 edx-django-release-util==1.1.0
     # via -r requirements/base.txt
-gevent==21.1.2
+gevent==21.8.0
     # via -r requirements/production.in
 greenlet==1.1.0
     # via gevent
@@ -130,7 +130,7 @@ mysqlclient==1.3.14
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
-newrelic==6.6.0.162
+newrelic==6.8.0.163
     # via -r requirements/production.in
 oauthlib==3.1.1
     # via

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -9,8 +9,10 @@ diff-cover
 django_dynamic_fixture
 edx-lint
 factory_boy
+httpretty
 mypy
 pycodestyle
 pytest
 pytest-cov
 pytest-django
+unittest2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,6 +4,8 @@
 #
 #    make upgrade
 #
+argparse==1.4.0
+    # via unittest2
 astroid==2.6.6
     # via
     #   -r requirements/test.in
@@ -120,6 +122,8 @@ factory-boy==3.2.0
     # via -r requirements/test.in
 faker==8.11.0
     # via factory-boy
+httpretty==1.1.3
+    # via -r requirements/test.in
 idna==3.2
     # via
     #   -r requirements/base.txt
@@ -149,6 +153,8 @@ jinja2-pluralize==0.3.0
     # via diff-cover
 lazy-object-proxy==1.6.0
     # via astroid
+linecache2==1.0.0
+    # via traceback2
 markupsafe==2.0.1
     # via
     #   -r requirements/base.txt
@@ -270,6 +276,7 @@ six==1.16.0
     #   python-dateutil
     #   social-auth-app-django
     #   social-auth-core
+    #   unittest2
 social-auth-app-django==4.0.0
     # via
     #   -r requirements/base.txt
@@ -296,8 +303,12 @@ toml==0.10.2
     #   pylint
     #   pytest
     #   pytest-cov
+traceback2==1.4.0
+    # via unittest2
 typing-extensions==3.10.0.0
     # via mypy
+unittest2==1.1.0
+    # via -r requirements/test.in
 uritemplate==3.0.1
     # via
     #   -r requirements/base.txt


### PR DESCRIPTION
Jwt new version `v2.0.0` has some [breaking changes](https://pyjwt.readthedocs.io/en/stable/changelog.html#dropped-deprecated-errors), this test will help to identify any issues before deployment.

Just checking encode and decodes works with params. We already saw few prod failures, this might help us little bit.

Verified this test against `v2.1.0` in this [PR](https://github.com/edx/blockstore/pull/117) and it is failing there.