### PR TITLE
temp: testing with pyjwt=2.1.0 version and auth-backend versions

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -11,8 +11,8 @@ djangorestframework
 djangorestframework-expander
 django-filter
 edx-api-doc-tools
-edx-auth-backends
 edx-django-release-util
 mysqlclient
 pytz
 sqlparse
+social-auth-app-django<5.0.0  # 5th aug release giving version conflict in upgrade job

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,7 +29,6 @@ defusedxml==0.7.1
     #   social-auth-core
 django==2.2.24
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   django-filter
@@ -68,8 +67,8 @@ drf-yasg==1.20.0
     # via edx-api-doc-tools
 edx-api-doc-tools==1.4.3
     # via -r requirements/base.in
-edx-auth-backends==3.4.0
-    # via -r requirements/base.in
+git+https://github.com/edx/auth-backends.git@375167f92be28ccf74cbb270ed91d6b7d26b1a0d#egg=edx-auth-backends==4.0.0
+    # via -r requirements/github.in
 edx-django-release-util==1.1.0
     # via -r requirements/base.in
 idna==3.2
@@ -96,9 +95,8 @@ pyblake2==1.1.2
     # via -r requirements/base.in
 pycparser==2.20
     # via cffi
-pyjwt[crypto]==1.7.1
+pyjwt[crypto]==2.1.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   edx-auth-backends
     #   social-auth-core
 pyparsing==2.4.7
@@ -128,12 +126,12 @@ six==1.16.0
     #   edx-auth-backends
     #   edx-django-release-util
     #   social-auth-app-django
-    #   social-auth-core
 social-auth-app-django==4.0.0
-    # via edx-auth-backends
-social-auth-core==4.0.2
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -r requirements/base.in
+    #   edx-auth-backends
+social-auth-core==4.1.0
+    # via
     #   edx-auth-backends
     #   social-auth-app-django
 sqlparse==0.4.1

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,9 +8,6 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
-# This file contains all common constraints for edx-repos
--c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-
 boto3<2.0
 
 # Not yet using Django 3.X. Using the 2.X LTS to mirror the LMS.

--- a/requirements/github.in
+++ b/requirements/github.in
@@ -1,3 +1,4 @@
 
 # Latest PyPi release does not have support for Django2.2, this commit from master does.
 git+https://github.com/alanjds/drf-nested-routers.git@8686392f91b114e01f3781807dea60e9a80d3e07#egg=drf-nested-routers==0.91
+git+https://github.com/edx/auth-backends.git@375167f92be28ccf74cbb270ed91d6b7d26b1a0d#egg=edx-auth-backends==4.0.0

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -83,7 +83,6 @@ diff-cover==6.2.1
     # via -r requirements/test.txt
 django==2.2.24
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   django-debug-toolbar
@@ -134,7 +133,7 @@ drf-yasg==1.20.0
     #   edx-api-doc-tools
 edx-api-doc-tools==1.4.3
     # via -r requirements/test.txt
-edx-auth-backends==3.4.0
+git+https://github.com/edx/auth-backends.git@375167f92be28ccf74cbb270ed91d6b7d26b1a0d#egg=edx-auth-backends==4.0.0
     # via -r requirements/test.txt
 edx-django-release-util==1.1.0
     # via -r requirements/test.txt
@@ -250,9 +249,8 @@ pygments==2.9.0
     #   -r requirements/test.txt
     #   diff-cover
     #   sphinx
-pyjwt[crypto]==1.7.1
+pyjwt[crypto]==2.1.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
     #   edx-auth-backends
     #   social-auth-core
@@ -344,7 +342,6 @@ six==1.16.0
     #   edx-sphinx-theme
     #   python-dateutil
     #   social-auth-app-django
-    #   social-auth-core
     #   sphinx
 snowballstemmer==2.1.0
     # via
@@ -354,9 +351,8 @@ social-auth-app-django==4.0.0
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends
-social-auth-core==4.0.2
+social-auth-core==4.1.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
     #   edx-auth-backends
     #   social-auth-app-django

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -10,7 +10,7 @@ pep517==0.11.0
     # via pip-tools
 pip-tools==6.2.0
     # via -r requirements/pip-tools.in
-tomli==1.2.0
+tomli==1.2.1
     # via pep517
 wheel==0.36.2
     # via pip-tools

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -6,11 +6,11 @@
 #
 attrs==21.2.0
     # via -r requirements/base.txt
-boto3==1.18.13
+boto3==1.18.15
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/production.in
-botocore==1.21.13
+botocore==1.21.15
     # via
     #   boto3
     #   s3transfer
@@ -48,7 +48,6 @@ defusedxml==0.7.1
     #   social-auth-core
 django==2.2.24
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   django-filter
@@ -92,13 +91,13 @@ drf-yasg==1.20.0
     #   edx-api-doc-tools
 edx-api-doc-tools==1.4.3
     # via -r requirements/base.txt
-edx-auth-backends==3.4.0
+git+https://github.com/edx/auth-backends.git@375167f92be28ccf74cbb270ed91d6b7d26b1a0d#egg=edx-auth-backends==4.0.0
     # via -r requirements/base.txt
 edx-django-release-util==1.1.0
     # via -r requirements/base.txt
-gevent==21.1.2
+gevent==21.8.0
     # via -r requirements/production.in
-greenlet==1.1.0
+greenlet==1.1.1
     # via gevent
 gunicorn==20.1.0
     # via -r requirements/production.in
@@ -130,7 +129,7 @@ mysqlclient==1.3.14
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
-newrelic==6.6.0.162
+newrelic==6.8.0.163
     # via -r requirements/production.in
 oauthlib==3.1.1
     # via
@@ -147,9 +146,8 @@ pycparser==2.20
     # via
     #   -r requirements/base.txt
     #   cffi
-pyjwt[crypto]==1.7.1
+pyjwt[crypto]==2.1.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
     #   edx-auth-backends
     #   social-auth-core
@@ -203,14 +201,12 @@ six==1.16.0
     #   python-dateutil
     #   python-memcached
     #   social-auth-app-django
-    #   social-auth-core
 social-auth-app-django==4.0.0
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
-social-auth-core==4.0.2
+social-auth-core==4.1.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
     #   edx-auth-backends
     #   social-auth-app-django

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -66,7 +66,6 @@ diff-cover==6.2.1
     # via -r requirements/test.in
 django==2.2.24
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   django-filter
@@ -110,7 +109,7 @@ drf-yasg==1.20.0
     #   edx-api-doc-tools
 edx-api-doc-tools==1.4.3
     # via -r requirements/base.txt
-edx-auth-backends==3.4.0
+git+https://github.com/edx/auth-backends.git@375167f92be28ccf74cbb270ed91d6b7d26b1a0d#egg=edx-auth-backends==4.0.0
     # via -r requirements/base.txt
 edx-django-release-util==1.1.0
     # via -r requirements/base.txt
@@ -191,9 +190,8 @@ pycparser==2.20
     #   cffi
 pygments==2.9.0
     # via diff-cover
-pyjwt[crypto]==1.7.1
+pyjwt[crypto]==2.1.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
     #   edx-auth-backends
     #   social-auth-core
@@ -269,14 +267,12 @@ six==1.16.0
     #   edx-lint
     #   python-dateutil
     #   social-auth-app-django
-    #   social-auth-core
 social-auth-app-django==4.0.0
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
-social-auth-core==4.0.2
+social-auth-core==4.1.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
     #   edx-auth-backends
     #   social-auth-app-django


### PR DESCRIPTION
Note: Not for merging.

temp: test behaviour with pyjwt=2.1.0 version and https://github.com/edx/auth-backends/pull/125 latest hash.
