### PR TITLE
Use django-enviro-2 instead of deprecated django-environ

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -5,7 +5,7 @@ attrs
 pyblake2
 django
 django-cors-headers
-django-environ
+django-environ-2
 django-waffle
 djangorestframework
 djangorestframework-expander

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -43,7 +43,7 @@ django-cors-headers==2.2.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-django-environ==0.4.5
+django-environ-2==2.1.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
@@ -128,6 +128,10 @@ six==1.16.0
     #   edx-django-release-util
     #   social-auth-app-django
 social-auth-app-django==4.0.0
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   edx-auth-backends
+social-auth-core==4.0.2
     # via
     #   -c requirements/common_constraints.txt
     #   edx-auth-backends

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -20,7 +20,7 @@ django>2.2,<2.3
 
 django-cors-headers>=2.2.0,<2.3
 
-django-environ==0.4.5
+django-environ-2==2.1.0
 
 django-filter==2.1.0
 

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -102,7 +102,7 @@ django-debug-toolbar==3.2.2
     # via -r requirements/local.in
 django-dynamic-fixture==3.1.1
     # via -r requirements/test.txt
-django-environ==0.4.5
+django-environ-2==2.1.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -63,7 +63,7 @@ django-cors-headers==2.2.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
-django-environ==0.4.5
+django-environ-2==2.1.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -82,7 +82,7 @@ django-cors-headers==2.2.1
     #   -r requirements/base.txt
 django-dynamic-fixture==3.1.1
     # via -r requirements/test.in
-django-environ==0.4.5
+django-environ-2==2.1.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt


### PR DESCRIPTION
## Description

The original [django-environ](https://github.com/joke2k/django-environ) package doesn't seem to be maintained and despite other prompts (joke2k/django-environ#292 and joke2k/django-environ#282) it doesn't look like the maintainer is not interested in bringing it back to life.

A fork was created, [django-environ-2](https://pypi.org/project/django-environ-2/), and that one is actively maintained and currently supports Django 3.2.

edx/upgrades#21

## Test Instructions

Run `make easyserver`.
